### PR TITLE
fix: use correct team name in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,15 @@
 # Default owners for everything in the repo
-* @prosperitypirate
+* @prosperitypirate/prosperity-pirates
 
 # Backend (Python/FastAPI)
-/backend/ @prosperitypirate
+/backend/ @prosperitypirate/prosperity-pirates
 
 # Plugin (Bun/TypeScript)
-/plugin/ @prosperitypirate
+/plugin/ @prosperitypirate/prosperity-pirates
 
 # Frontend (Next.js)
-/frontend/ @prosperitypirate
+/frontend/ @prosperitypirate/prosperity-pirates
 
 # Infrastructure
-docker-compose.yml @prosperitypirate
-/scripts/ @prosperitypirate
+docker-compose.yml @prosperitypirate/prosperity-pirates
+/scripts/ @prosperitypirate/prosperity-pirates


### PR DESCRIPTION
## Summary
- Fixes CODEOWNERS errors caused by referencing non-existent team `@prosperitypirate/core`
- Updates all entries to use the correct team `@prosperitypirate/prosperity-pirates`