### PR TITLE
fix: add explicit read-only permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # ── Plugin ────────────────────────────────────────────────────────────────────
   plugin:


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: read` at the workflow level to satisfy the principle of least privilege
- Resolves CodeQL alerts #2, #3, and #6 (missing-workflow-permissions)