### PR TITLE
chore(ci): switch opencode-review bot to haiku-4-5

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -36,7 +36,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          model: anthropic/claude-sonnet-4-6
+          model: anthropic/claude-haiku-4-5
           share: false
           prompt: |
             Review this pull request for the opencode-memory project (a self-hosted


### PR DESCRIPTION
## Summary

- Switches the OpenCode PR review bot from `anthropic/claude-sonnet-4-6` to `anthropic/claude-haiku-4-5`
- Same Anthropic API key, no new credentials needed
- ~3x cost reduction ($3/$15 → $1/$5 per M tokens) with no expected quality loss for code review tasks