### PR TITLE
ci: add npm publish workflow for automated releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,76 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (skip actual publish)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: plugin-v2
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        working-directory: plugin-v2
+        run: bunx tsc --noEmit
+
+      - name: Build plugin
+        working-directory: plugin-v2
+        run: bun run build
+
+      - name: Verify build output
+        working-directory: plugin-v2
+        run: |
+          test -f dist/index.js || (echo "❌ dist/index.js missing" && exit 1)
+          test -f dist/cli.js || (echo "❌ dist/cli.js missing" && exit 1)
+          echo "✅ Build artifacts verified"
+          ls -la dist/
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Set version from release tag
+        if: github.event_name == 'release'
+        working-directory: plugin-v2
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Publishing version: $VERSION"
+          # Use node to update package.json (preserves formatting better than sed)
+          node -e "
+            const pkg = require('./package.json');
+            pkg.version = '$VERSION';
+            require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, '\t') + '\n');
+          "
+
+      - name: Publish (dry run)
+        if: inputs.dry_run == true || inputs.dry_run == 'true'
+        working-directory: plugin-v2
+        run: npm publish --dry-run --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: github.event_name == 'release' || inputs.dry_run != true
+        working-directory: plugin-v2
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow (`.github/workflows/publish.yml`) that automates npm publishing.

## How it works

- **Trigger**: GitHub Release creation (auto-sets version from release tag) or manual dispatch with dry-run option
- **Steps**: Install → type check → build → verify artifacts → publish with provenance
- **Version**: Extracted from release tag (`v0.3.0` → `0.3.0`), no manual version bumps needed

## Prerequisites before first publish

1. Add `NPM_TOKEN` secret to repo settings
2. Remove `"private": true` from `plugin-v2/package.json`
3. Update package name to `codexfi` when ready for rebrand
4. Create first GitHub Release with tag `v0.3.0`

## Why this matters

The vision is `bunx codexfi install` as a one-liner. That requires the package on npm. This workflow makes publishing a one-click operation — create a release, and the package is on npm within minutes.

Relates to #53