### PR TITLE
fix(ci): add CI gate job so release-please PRs never get stuck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,22 @@ jobs:
       - name: Skip — no plugin changes
         if: steps.changes.outputs.plugin != 'true'
         run: echo "No plugin/testing changes detected — skipping tests"
+
+  # ── Status gate ────────────────────────────────────────────────────────────
+  # Always runs and always reports a status to GitHub. This is the single
+  # required check in branch protection. Build/Test are allowed to skip (e.g.
+  # on release-please PRs that only touch package.json/CHANGELOG.md) without
+  # blocking the merge — but they must not have actually failed.
+  status:
+    name: CI
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    if: always()
+    steps:
+      - name: Verify build and test passed or were skipped
+        run: |
+          if [[ "${{ needs.build.result }}" == "failure" || "${{ needs.test.result }}" == "failure" ]]; then
+            echo "Build or Test failed — blocking merge"
+            exit 1
+          fi
+          echo "CI passed (build: ${{ needs.build.result }}, test: ${{ needs.test.result }})"


### PR DESCRIPTION
## Summary

- Adds a \`status\` gate job (name: \`CI\`) to \`ci.yml\` that always runs and always reports a status to GitHub
- Fixes release-please PRs getting stuck on \"Expected — Waiting to be reported\" for \`Build\` and \`Test\`
- After this merges, branch protection will be updated to require only \`CI\` instead of \`Build\`/\`Test\` separately

## Related issue

Closes #

## Problem

\`Build\` and \`Test\` use \`dorny/paths-filter\` to skip when no plugin files changed. When they skip, they never post a status to GitHub. GitHub then shows \"Expected — Waiting to be reported\" indefinitely on required checks — blocking release-please PRs from merging without an admin bypass.

## Solution

The \`CI\` gate job:
- \`needs: [build, test]\` + \`if: always()\` — always runs regardless of upstream skip
- Fails if \`Build\` or \`Test\` actually failed
- Passes if they passed or were legitimately skipped
- Always reports a green/red status to GitHub

## Changes

| File | Change |
|---|---|
| \`.github/workflows/ci.yml\` | Added \`status\` gate job at bottom |

## Testing

Since \`ci.yml\` is in the paths filter, \`Build\` and \`Test\` will run on this PR. All three jobs (\`Build\`, \`Test\`, \`CI\`) should be green.

After merge: branch protection updated to require only \`CI\` + \`enforce_admins\` enabled.

## Checklist

- [x] Label(s) added
- [x] Squash commit title uses correct conventional commit prefix
- [ ] Benchmark run completed (if touching retrieval, memory store, or prompts) — N/A
- [x] No secrets or hardcoded paths introduced