### PR TITLE
fix(plugin): improve install UX — unicode rendering fix, sequential provider setup, dynamic version

### DIFF
--- a/plugin/src/cli/index.ts
+++ b/plugin/src/cli/index.ts
@@ -58,10 +58,11 @@ loadEnvFile();
 
 import { parseArgs } from "./args.js";
 import * as fmt from "./fmt.js";
+import pkg from "../../package.json";
 
 // ── Version ─────────────────────────────────────────────────────────────────────
 
-const VERSION = "0.3.0";
+const VERSION = pkg.version;
 
 // ── Command registry ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes two UX bugs discovered during first-time install testing on a non-UTF-8 terminal (issue #77), plus a pre-existing version string bug found during review.

Closes #77

---

## Bug 1 — Garbled terminal output (`fmt.ts`)

**Before:**
```
â Setup complete!
â¢ Restart OpenCode to activate the plugin.
âââââââââ
```

**After:**
```
✓ Setup complete!
• Restart OpenCode to activate the plugin.
─────────
```

**Root cause:** `sym` values were gated behind `supportsColor` (which only checks `isTTY`). Color support and UTF-8 encoding capability are independent — a terminal can support ANSI colors but decode multi-byte UTF-8 as Latin-1, producing garbled output. `sym.dash` also had no ASCII fallback at all.

**Fix:** Added a separate `detectUnicode()` function that checks:
1. `TERM_PROGRAM` for known-good values (`iTerm.app`, `Apple_Terminal`, `vscode`, `WindowsTerminal`)
2. Locale env vars (`LANG` / `LC_ALL` / `LC_CTYPE`) for `UTF-8`/`utf8`
3. `WT_SESSION` (Windows Terminal)

All `sym` values and spinner frames now gate behind `supportsUnicode`. `sym.dash` gets `-` as ASCII fallback.

---

## Bug 2 — Install only collects one extraction provider key (`install.ts`)

**Before:** `resolveExistingExtraction()` was a first-match-wins loop — hit `XAI_API_KEY` in env, returned immediately, Anthropic and Google were never prompted.

**After:** Sequential walk over all 3 providers:
- Key already found → show masked value + ask `Keep? [Y/n]`
- No key found → prompt for one, or Enter to skip
- Zero keys collected after all 3 → `process.exit(1)` with clear error message

---

## Bug 3 — Hardcoded version string (`index.ts`)

**Before:** `const VERSION = "0.3.0"` — hardcoded and 2 patch versions behind `package.json`.

**After:** `const VERSION = pkg.version` — reads from `package.json` at runtime. Automatically correct after every release-please bump, no manual update needed.

---

## Files changed

| File | Change |
|---|---|
| `plugin/src/cli/fmt.ts` | Add `detectUnicode()`, gate `sym` + spinners behind `supportsUnicode`, add `sym.dash` ASCII fallback |
| `plugin/src/cli/commands/install.ts` | Replace `resolveExistingExtraction()` with sequential per-provider loop |
| `plugin/src/cli/index.ts` | Read `VERSION` from `package.json` instead of hardcoded string |

---

## Testing

- `LANG= LC_ALL= TERM_PROGRAM=` → pure ASCII output confirmed
- `LANG=en_US.UTF-8` → Unicode symbols confirmed
- `TERM_PROGRAM=Apple_Terminal` with no locale → Unicode confirmed (covers the exact reported scenario)
- Sequential provider logic verified
- `codexfi --version` now returns `0.4.2` matching `package.json`
- `bun run typecheck` clean
- `bun run build` clean
