### PR TITLE
fix(plugin): upgrade @lancedb/lancedb 0.15.0 → 0.26.2

### DIFF
--- a/plugin/bun.lock
+++ b/plugin/bun.lock
@@ -1,10 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "codexfi",
       "dependencies": {
-        "@lancedb/lancedb": "^0.15.0",
+        "@lancedb/lancedb": "0.26.2",
         "@opencode-ai/plugin": "^1.2.11",
         "@opencode-ai/sdk": "^1.2.11",
         "zod": "^4.3.6",
@@ -16,23 +17,21 @@
     },
   },
   "packages": {
-    "@lancedb/lancedb": ["@lancedb/lancedb@0.15.0", "", { "dependencies": { "reflect-metadata": "^0.2.2" }, "optionalDependencies": { "@lancedb/lancedb-darwin-arm64": "0.15.0", "@lancedb/lancedb-darwin-x64": "0.15.0", "@lancedb/lancedb-linux-arm64-gnu": "0.15.0", "@lancedb/lancedb-linux-arm64-musl": "0.15.0", "@lancedb/lancedb-linux-x64-gnu": "0.15.0", "@lancedb/lancedb-linux-x64-musl": "0.15.0", "@lancedb/lancedb-win32-arm64-msvc": "0.15.0", "@lancedb/lancedb-win32-x64-msvc": "0.15.0" }, "peerDependencies": { "apache-arrow": ">=15.0.0 <=18.1.0" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ] }, "sha512-qm3GXLA17/nFGUwrOEuFNW0Qg2gvCtp+yAs6qoCM6vftIreqzp8d4Hio6eG/YojS9XqPnR2q+zIeIFy12Ywvxg=="],
+    "@lancedb/lancedb": ["@lancedb/lancedb@0.26.2", "", { "dependencies": { "reflect-metadata": "^0.2.2" }, "optionalDependencies": { "@lancedb/lancedb-darwin-arm64": "0.26.2", "@lancedb/lancedb-linux-arm64-gnu": "0.26.2", "@lancedb/lancedb-linux-arm64-musl": "0.26.2", "@lancedb/lancedb-linux-x64-gnu": "0.26.2", "@lancedb/lancedb-linux-x64-musl": "0.26.2", "@lancedb/lancedb-win32-arm64-msvc": "0.26.2", "@lancedb/lancedb-win32-x64-msvc": "0.26.2" }, "peerDependencies": { "apache-arrow": ">=15.0.0 <=18.1.0" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ] }, "sha512-umk4WMCTwJntLquwvUbpqE+TXREolcQVL9MHcxr8EhRjsha88+ATJ4QuS/hpyiE1CG3R/XcgrMgJAGkziPC/gA=="],
 
-    "@lancedb/lancedb-darwin-arm64": ["@lancedb/lancedb-darwin-arm64@0.15.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-e6eiS1dUdSx3G3JXFEn5bk6I26GR7UM2QwQ1YMrTsg7IvGDqKmXc/s5j4jpJH0mzm7rwqh+OAILPIjr7DoUCDA=="],
+    "@lancedb/lancedb-darwin-arm64": ["@lancedb/lancedb-darwin-arm64@0.26.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LAZ/v261eTlv44KoEm+AdqGnohS9IbVVVJkH9+8JTqwhe/k4j4Af8X9cD18tsaJAAtrGxxOCyIJ3wZTiBqrkCw=="],
 
-    "@lancedb/lancedb-darwin-x64": ["@lancedb/lancedb-darwin-x64@0.15.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-kEgigrqKf954egDbUdIp86tjVfFmTCTcq2Hydw/WLc+LI++46aeT2MsJv0CQpkNFMfh/T2G18FsDYLKH0zTaow=="],
+    "@lancedb/lancedb-linux-arm64-gnu": ["@lancedb/lancedb-linux-arm64-gnu@0.26.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-guHKm+zvuQB22dgyn6/sYZJvD6IL9lC24cl6ZuzVX/jYgag/gNLHT86HongrcBjgdjI6+YIGmdfD6b/iAKxn3Q=="],
 
-    "@lancedb/lancedb-linux-arm64-gnu": ["@lancedb/lancedb-linux-arm64-gnu@0.15.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-TnpbBT9kaSYQqastJ+S5jm4S5ZYBx18X8PHQ1ic3yMIdPTjCWauj+owDovOpiXK9ucjmi/FnUp8bKNxGnlqmEg=="],
+    "@lancedb/lancedb-linux-arm64-musl": ["@lancedb/lancedb-linux-arm64-musl@0.26.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-pR6Hs/0iphItrJYYLf/yrqCC+scPcHpCGl6rHqcU2GHxo5RFpzlMzqW1DiXScGiBRuCcD9HIMec+kBsOgXv4GQ=="],
 
-    "@lancedb/lancedb-linux-arm64-musl": ["@lancedb/lancedb-linux-arm64-musl@0.15.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-fe8LnC9YKbLgEJiLQhyVj+xz1d1RgWKs+rLSYPxaD3xQBo3kMC94Esq+xfrdNkSFvPgchRTvBA9jDYJjJL8rcg=="],
+    "@lancedb/lancedb-linux-x64-gnu": ["@lancedb/lancedb-linux-x64-gnu@0.26.2", "", { "os": "linux", "cpu": "x64" }, "sha512-u4UUSPwd2YecgGqWjh9W0MHKgsVwB2Ch2ROpF8AY+IA7kpGsbB18R1/t7v2B0q7pahRy20dgsaku5LH1zuzMRQ=="],
 
-    "@lancedb/lancedb-linux-x64-gnu": ["@lancedb/lancedb-linux-x64-gnu@0.15.0", "", { "os": "linux", "cpu": "x64" }, "sha512-0lKEc3M06ax3RozBbxHuNN9qWqhJUiKDnRC3ttsbmo4VrOUBvAO3fKoaRkjZhAA8q4+EdhZnCaQZezsk60f7Ag=="],
+    "@lancedb/lancedb-linux-x64-musl": ["@lancedb/lancedb-linux-x64-musl@0.26.2", "", { "os": "linux", "cpu": "x64" }, "sha512-XIS4qkVfGlzmsUPqAG2iKt8ykuz28GfemGC0ijXwu04kC1pYiCFzTpB3UIZjm5oM7OTync1aQ3mGTj1oCciSPA=="],
 
-    "@lancedb/lancedb-linux-x64-musl": ["@lancedb/lancedb-linux-x64-musl@0.15.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ls+ikV7vWyVnqVT7bMmuqfGCwVR5JzPIfJ5iZ4rkjU4iTIQRpY7u/cTe9rGKt/+psliji8x6PPZHpfdGXHmleQ=="],
+    "@lancedb/lancedb-win32-arm64-msvc": ["@lancedb/lancedb-win32-arm64-msvc@0.26.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-//tZDPitm2PxNvalHP+m+Pf6VvFAeQgcht1+HJnutjH4gp6xYW6ynQlWWFDBmz9WRkUT+mXu2O4FUIhbdNaJSQ=="],
 
-    "@lancedb/lancedb-win32-arm64-msvc": ["@lancedb/lancedb-win32-arm64-msvc@0.15.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-C30A+nDaJ4jhjN76hRcp28Eq+G48SR9wO3i1zGm0ZAEcRV1t9O1fAp6g18IPT65Qyu/hXJBgBdVHtent+qg9Ng=="],
-
-    "@lancedb/lancedb-win32-x64-msvc": ["@lancedb/lancedb-win32-x64-msvc@0.15.0", "", { "os": "win32", "cpu": "x64" }, "sha512-amXzIAxqrHyp+c9TpIDI8ze1uCqWC6HXQIoXkoMQrBXoUUo8tJORH2yGAsa3TSgjZDDjg0HPA33dYLhOLk1m8g=="],
+    "@lancedb/lancedb-win32-x64-msvc": ["@lancedb/lancedb-win32-x64-msvc@0.26.2", "", { "os": "win32", "cpu": "x64" }, "sha512-GH3pfyzicgPGTb84xMXgujlWDaAnBTmUyjooYiCE2tC24BaehX4hgFhXivamzAEsF5U2eVsA/J60Ppif+skAbA=="],
 
     "@opencode-ai/plugin": ["@opencode-ai/plugin@1.2.14", "", { "dependencies": { "@opencode-ai/sdk": "1.2.14", "zod": "4.1.8" } }, "sha512-36dPaIaNPMjA5jnFAbOzvKe78dbUkKXF8hgs8PNRXiAaTSzoIapBC/xkADVRO66tmLyZhoGFSBkVeJUpOyyiew=="],
 

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -18,7 +18,7 @@
 		"smoke:e2e": "bun run src/smoke-e2e.ts"
 	},
 	"dependencies": {
-		"@lancedb/lancedb": "^0.15.0",
+		"@lancedb/lancedb": "0.26.2",
 		"@opencode-ai/plugin": "^1.2.11",
 		"@opencode-ai/sdk": "^1.2.11",
 		"zod": "^4.3.6"


### PR DESCRIPTION
## Summary

Upgrades `@lancedb/lancedb` from `0.15.0` to `0.26.2`, superseding Dependabot PR #94 which was blocked by a stale `bun.lock`.

## Why this is safe

The two breaking changes in the 0.15 → 0.26 range are both irrelevant to this codebase:

- **macOS x86 NAPI binaries deprecated** — we run on Apple Silicon (arm64). Unaffected.
- **Namespace model refactor** — codexfi uses local embedded LanceDB only, no namespaces. Unaffected.

The API surface we use (`connect`, `openTable`, `createTable`, `search`, `add`, `update`, `delete`, `countRows`, `distanceType`, `where`, `limit`, `toArray`) is unchanged across all versions in this range.

## Test results

| Suite | Result |
|---|---|
| Typecheck | ✅ clean |
| Build | ✅ 89 modules, index.js 0.51MB, cli.js 128KB |
| Unit (54 tests) | ✅ 54/54 pass |
| Integration (28 tests) | ✅ 28/28 pass |
| `spike.ts` (lancedb stress test) | ✅ all pass — connect, createTable, add, search, where, update, delete, mergeInsert, optimize, version, concurrent writes, search-during-write, performance benchmark |
| Manual smoke test (`codexfi install`) | ✅ clean output |

## Relation to Dependabot PR #94

Dependabot PR #94 targets the same version (`0.26.2`) but has a failing Build CI check due to a stale `bun.lock`. This PR regenerates `bun.lock` correctly and includes extensive local validation. Merging this PR renders #94 moot.