### PR TITLE
chore: silence Dependabot for @lancedb/lancedb until upstream darwin-x64 build bug is fixed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,14 @@ updates:
     labels:
       - "dependencies"
       - "plugin"
+    ignore:
+      # @lancedb/lancedb: pinned at 0.15.0 — darwin-x64 NAPI binary missing from all
+      # versions >= 0.24.1 due to upstream build bug. Upgrading would break Intel Mac users.
+      # Track: https://github.com/lancedb/lancedb/issues/2937
+      # To upgrade: confirm darwin-x64 is restored, remove this ignore rule, then run
+      # spike.ts + full test suite (unit + integration) before merging.
+      - dependency-name: "@lancedb/lancedb"
+        versions: ["*"]
 
   # Frontend (npm/bun) dependencies
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary

Adds a Dependabot `ignore` rule for `@lancedb/lancedb` to prevent recurring PRs that cannot be safely merged right now.

## Why

`@lancedb/lancedb-darwin-x64` (Intel Mac NAPI binary) is absent from every lancedb release >= 0.24.1 due to an upstream build bug — [lancedb/lancedb#2937](https://github.com/lancedb/lancedb/issues/2937), filed Jan 2026, still open with no maintainer response.

Upgrading from 0.15.0 would silently break any codexfi user on Intel Mac at runtime with a hard import failure. This was investigated thoroughly in PR #100 (now closed).

## What to do when unblocked

When lancedb/lancedb#2937 is resolved and a version with `darwin-x64` restored is published:

1. Remove the `ignore` block added by this PR from `.github/dependabot.yml`
2. Run `spike.ts` + full test suite (unit + integration) — all infrastructure is already in place
3. Merge the resulting Dependabot PR