### PR TITLE
fix(ci): gracefully handle missing VERCEL_GIT_PREVIOUS_SHA in shallow clone

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD^} HEAD ./"
+  "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD^} HEAD ./ 2>/dev/null || exit 1"
 }


### PR DESCRIPTION
## Summary

- Fixes Vercel deployments failing with `fatal: bad object` / exit code 128 when `VERCEL_GIT_PREVIOUS_SHA` refers to a commit outside the shallow clone depth
- Adds `2>/dev/null || exit 1` to the `ignoreCommand` so any git failure degrades gracefully to "run the build" instead of crashing the deployment

## Root cause

The `ignoreCommand` in `website/vercel.json` uses `VERCEL_GIT_PREVIOUS_SHA` to skip builds when no website files changed. Vercel does a shallow clone, so if the previous SHA is older than the clone depth, git exits 128 (`fatal: bad object`). Vercel treats 128 as a deployment error rather than "please build".

This only surfaced on the PR #107 merge — the first merge in a while that touched no website files, causing `VERCEL_GIT_PREVIOUS_SHA` to point to an old-enough commit to be outside the clone.

## Change

```diff
- "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD^} HEAD ./"
+ "ignoreCommand": "git diff --quiet ${VERCEL_GIT_PREVIOUS_SHA:-HEAD^} HEAD ./ 2>/dev/null || exit 1"
```

Worst case: unnecessary website build triggered. Never: a broken deployment.

Closes #109