### PR TITLE
fix(security): patch 4 Hono transitive dependency vulnerabilities

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -42,6 +42,10 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "sharp"
-    ]
+    ],
+    "overrides": {
+      "hono": ">=4.12.4",
+      "@hono/node-server": ">=1.19.10"
+    }
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  hono: '>=4.12.4'
+  '@hono/node-server': '>=1.19.10'
+
 importers:
 
   .:
@@ -413,11 +417,11 @@ packages:
       tailwindcss:
         optional: true
 
-  '@hono/node-server@1.19.9':
-    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.4'
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -1997,8 +2001,8 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
-  hono@4.12.3:
-    resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
+  hono@4.12.5:
+    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
     engines: {node: '>=16.9.0'}
 
   html-void-elements@3.0.0:
@@ -3588,9 +3592,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.1
 
-  '@hono/node-server@1.19.9(hono@4.12.3)':
+  '@hono/node-server@1.19.11(hono@4.12.5)':
     dependencies:
-      hono: 4.12.3
+      hono: 4.12.5
 
   '@img/colour@1.0.0':
     optional: true
@@ -3768,7 +3772,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.3)
+      '@hono/node-server': 1.19.11(hono@4.12.5)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3778,7 +3782,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.12.3
+      hono: 4.12.5
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5172,7 +5176,7 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
-  hono@4.12.3: {}
+  hono@4.12.5: {}
 
   html-void-elements@3.0.0: {}
 


### PR DESCRIPTION
## Summary

Patches 4 Dependabot security alerts by adding `pnpm.overrides` to `website/package.json`, forcing transitive dependencies `hono` and `@hono/node-server` to their patched versions.

Closes #116

## Vulnerabilities Resolved

| CVE | Package | Severity | CVSS | Description |
|-----|---------|----------|------|-------------|
| CVE-2026-29045 | `hono` | **High** | 7.5 | Arbitrary file access via `serveStatic` URL decoding mismatch |
| CVE-2026-29087 | `@hono/node-server` | **High** | 7.5 | Auth bypass for static paths via encoded slashes (`%2F`) |
| CVE-2026-29085 | `hono` | Moderate | 6.5 | SSE Control Field Injection via CR/LF in `writeSSE()` |
| CVE-2026-29086 | `hono` | Moderate | 5.4 | Cookie Attribute Injection via unsanitized domain/path in `setCookie()` |

## Version Changes

| Package | Before | After | Required |
|---------|--------|-------|----------|
| `hono` | 4.12.3 | **4.12.5** | >= 4.12.4 |
| `@hono/node-server` | 1.19.9 | **1.19.11** | >= 1.19.10 |

## Context

These are **transitive dev-only dependencies** — not direct dependencies of the website:

```
shadcn (devDependency, CLI tool)
  └─ @modelcontextprotocol/sdk
       ├─ hono          ← patched
       └─ @hono/node-server  ← patched
```

The website is a Next.js app and does not use any of the vulnerable Hono APIs (`serveStatic`, `writeSSE`, `setCookie`). These packages are never shipped to production. However, patching maintains a clean security posture and clears Dependabot alerts.

## Changes

- `website/package.json`: Added `pnpm.overrides` for `hono` and `@hono/node-server`
- `website/pnpm-lock.yaml`: Regenerated with patched versions

## Verification

- [x] `pnpm install` succeeds
- [x] Lockfile resolves patched versions (`hono@4.12.5`, `@hono/node-server@1.19.11`)
- [x] `pnpm build` (Next.js production build) passes cleanly
- [x] No code changes required — overrides only affect transitive dependency resolution

## Risk

**Minimal.** Patch-level bumps of transitive dev-only dependencies. No API surface changes. No production code affected.