### PR TITLE
fix(ci): inject PR metadata into review bot to fix false-positive label warnings

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -35,6 +35,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Fetch PR metadata
+        id: pr-meta
+        run: |
+          LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '[.labels[].name] | join(", ")' 2>/dev/null || echo "none")
+          ASSIGNEES=$(gh pr view ${{ github.event.pull_request.number }} --json assignees --jq '[.assignees[].login] | join(", ")' 2>/dev/null || echo "none")
+          echo "labels=${LABELS:-none}" >> "$GITHUB_OUTPUT"
+          echo "assignees=${ASSIGNEES:-none}" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: anomalyco/opencode/github@latest
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -90,11 +100,17 @@ jobs:
             - README or CHANGELOG updates needed for user-visible changes
 
             ## PR hygiene
-            Flag as Warning if missing:
-            - At least one label applied (bug, enhancement, memory-quality, chore, ci,
-              backend, frontend, plugin, benchmark, security, documentation, research)
-            - A related issue linked (e.g. "Closes #N") — not required for chore/ci/docs PRs
-            - PR description is not empty
+            Current PR metadata (fetched via GitHub API):
+            - Labels: ${{ steps.pr-meta.outputs.labels }}
+            - Assignees: ${{ steps.pr-meta.outputs.assignees }}
+
+            Flag as Warning if:
+            - Labels is "none" (expected: at least one of bug, enhancement,
+              memory-quality, chore, ci, backend, frontend, plugin, benchmark,
+              security, documentation, research, website, dependencies)
+            - Assignees is "none" (every PR should have an assignee)
+            - A related issue is not linked (e.g. "Closes #N") — not required for chore/ci/docs PRs
+            - PR description is empty
 
             Post findings grouped by severity: **Critical**, **Warning**, **Suggestion**.
             Skip empty sections. If the PR looks good, say so briefly.


### PR DESCRIPTION
## Summary

Fixes the OpenCode review bot consistently producing false-positive warnings claiming "No label applied to the PR" even when labels are present.

Closes #118

## Root Cause

The `anomalyco/opencode/github` action only provides the Haiku model with the **diff and PR body text** — it does not inject PR metadata (labels, assignees, milestones) into the model's context. The prompt instructed the model to check for labels, but the model had no data to verify against, so it defaulted to flagging them as missing on every single review.

## Fix

**Added a `Fetch PR metadata` step** (lines 38-46) that runs before the OpenCode action:

```yaml
- name: Fetch PR metadata
  id: pr-meta
  run: |
    LABELS=$(gh pr view ... --json labels --jq '[.labels[].name] | join(", ")')
    ASSIGNEES=$(gh pr view ... --json assignees --jq '[.assignees[].login] | join(", ")')
```

The fetched data is then injected into the prompt as structured context:

```
Current PR metadata (fetched via GitHub API):
- Labels: security, website, dependencies, chore
- Assignees: clarkbalan
```

The model can now make **data-driven judgments** instead of guessing.

## Before / After

| Aspect | Before | After |
|--------|--------|-------|
| Label data available to model | None | Real labels from GitHub API |
| Assignee data available to model | None | Real assignees from GitHub API |
| False-positive label warnings | Every PR | Only when labels are truly missing |
| Assignee checking | Not checked | Now checked |

## Changes

- `.github/workflows/opencode-review.yml`: Added `Fetch PR metadata` step + updated PR hygiene prompt section

## Risk

**Minimal.** This only changes the CI workflow prompt — no production code affected. If the `gh pr view` command fails, it falls back to `"none"`, which correctly triggers the warning (fail-safe behavior).