### PR TITLE
fix: revert db.ts to simple createRequire — 0.5.3 broke lancedb loading

### DIFF
--- a/plugin/src/db.ts
+++ b/plugin/src/db.ts
@@ -1,12 +1,15 @@
-// Use dynamic import() instead of static ESM import or createRequire so that
-// @lancedb/lancedb loads correctly in all OpenCode runtimes (terminal Bun SEA,
-// desktop Bun SEA, and plain Node.js).  Static imports resolve from the host
-// binary's context (empty namespace in Bun SEA), and createRequire is rejected
-// by the desktop app's Bun SEA for async ESM modules.
+// Use createRequire to load @lancedb/lancedb so that the Bun SEA runtime
+// (used by OpenCode) resolves the module from THIS file's node_modules
+// instead of the host binary's bundled module context.  A plain static
+// `import * as lancedb` resolves to an empty namespace `{}` in Bun SEA.
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type * as LanceDB from "@lancedb/lancedb";
 import { EMBEDDING_DIMS } from "./config.js";
+
+const _require = createRequire(import.meta.url);
+const lancedb = _require("@lancedb/lancedb") as typeof LanceDB;
 
 const DB_PATH = join(homedir(), ".codexfi", "lancedb");
 const TABLE_NAME = "memories";
@@ -15,7 +18,6 @@ let db: LanceDB.Connection;
 let table: LanceDB.Table;
 
 export async function init(dbPath?: string): Promise<void> {
-	const lancedb: typeof LanceDB = await import("@lancedb/lancedb");
 	db = await lancedb.connect(dbPath ?? DB_PATH);
 	try {
 		table = await db.openTable(TABLE_NAME);

--- a/testing/src/integration/plugin-load.test.ts
+++ b/testing/src/integration/plugin-load.test.ts
@@ -3,26 +3,22 @@
  *
  * WHAT THIS TESTS
  * ---------------
- * The bug: when OpenCode (a Bun SEA native binary) dynamically loads the
- * codexfi plugin dist, static ESM imports and createRequire() both fail to
- * resolve @lancedb/lancedb in certain Bun SEA builds:
+ * When OpenCode (a Bun SEA native binary) loads the codexfi plugin, a plain
+ * static `import * as lancedb from "@lancedb/lancedb"` resolves to an empty
+ * namespace `{}` because the Bun SEA resolver looks inside the host binary
+ * instead of the plugin's node_modules on disk.
  *
- *   - Static `import * as lancedb` resolves to empty `{}` in Bun SEA
- *   - `createRequire()` is rejected by the desktop app's Bun SEA with
- *     "require() async module ... is unsupported"
- *
- * The fix: `await import("@lancedb/lancedb")` — standard dynamic import that
- * works in all environments (Node.js, Bun, terminal Bun SEA, desktop Bun SEA).
+ * The fix: `createRequire(import.meta.url)("@lancedb/lancedb")` which
+ * resolves from the dist file's actual filesystem location.
  *
  * HOW WE SIMULATE IT
  * ------------------
  * We spawn a child `bun` process whose cwd is a temp directory that has NO
  * node_modules (simulating a host process that doesn't own codexfi's deps).
- * The child does a dynamic `import()` of `@lancedb/lancedb` using the same
- * resolution base as the dist file, and verifies `connect` is a function.
+ * The child uses createRequire anchored to the dist file path, same as db.ts.
  *
  * If the static ESM import bug were present the child would print
- * "lancedb.connect is not a function" and exit 1 — this test would catch it.
+ * "lancedb.connect is not a function" and exit 1.
  */
 
 import { describe, test, expect, afterAll } from "bun:test";
@@ -42,27 +38,23 @@ afterAll(() => {
 });
 
 describe("plugin-load (Bun SEA lancedb regression)", () => {
-	test("dist resolves @lancedb/lancedb via dynamic import() from an external cwd", async () => {
+	test("dist resolves @lancedb/lancedb via createRequire from an external cwd", async () => {
 		// 1. Create an isolated working directory with no node_modules
 		const hostCwd = mkdtempSync(join(tmpdir(), "oc-host-"));
 		tempDirs.push(hostCwd);
 
-		// 2. Write a small probe script into the host cwd.
-		//    Replicates the exact `await import("@lancedb/lancedb")` pattern
-		//    used in db.ts init(). The import specifier is bare, so Bun/Node
-		//    must resolve it from the dist file's location (codexfi's own
-		//    node_modules). If the old static-import or createRequire bug
-		//    were present, connect would be undefined or the import would throw.
+		// 2. Write a probe script that uses createRequire (same as db.ts)
 		const probeScript = join(hostCwd, "probe.mjs");
 		writeFileSync(probeScript, `
+import { createRequire } from "node:module";
 try {
-  // Dynamic import — same approach as db.ts
-  const lancedb = await import("@lancedb/lancedb");
+  const _require = createRequire("${DIST_PATH}");
+  const lancedb = _require("@lancedb/lancedb");
   if (typeof lancedb.connect !== "function") {
     console.error("FAIL: lancedb.connect is not a function — got:", typeof lancedb.connect);
     process.exit(1);
   }
-  console.log("OK: lancedb.connect is a function — dynamic import resolved correctly");
+  console.log("OK: lancedb.connect is a function — createRequire resolved correctly");
   process.exit(0);
 } catch (err) {
   console.error("FAIL:", err.message ?? String(err));
@@ -70,18 +62,12 @@ try {
 }
 `.trimStart());
 
-		// 3. Spawn bun from the host cwd (which has no node_modules).
-		//    Pass NODE_PATH so the bare specifier resolves to codexfi's deps,
-		//    simulating what happens when OpenCode loads the plugin from cache.
-		const pluginNodeModules = resolve(__dirname, "../../../plugin/node_modules");
+		// 3. Spawn bun from the host cwd (no node_modules).
 		const proc = Bun.spawn(["bun", "run", probeScript], {
 			cwd: hostCwd,
 			stdout: "pipe",
 			stderr: "pipe",
-			env: {
-				...process.env,
-				NODE_PATH: pluginNodeModules,
-			},
+			env: { ...process.env },
 		});
 
 		const [stdout, stderr] = await Promise.all([
@@ -92,12 +78,11 @@ try {
 
 		// 4. Assert
 		if (proc.exitCode !== 0) {
-			// Print diagnostics so failures are easy to debug in CI
 			console.error("--- probe stdout ---\n" + stdout);
 			console.error("--- probe stderr ---\n" + stderr);
 		}
 
 		expect(proc.exitCode).toBe(0);
 		expect(stdout).toContain("OK:");
-	}, 30_000); // LanceDB init can take a few seconds on first run
+	}, 30_000);
 });


### PR DESCRIPTION
## Summary

- Revert `db.ts` to the clean `createRequire(import.meta.url)` pattern from v0.5.2
- Remove multi-strategy `loadLanceDB` function and dead fallback code
- Update regression test to verify `createRequire` resolution

## Problem

v0.5.3 (#145) replaced `createRequire` with `await import("@lancedb/lancedb")` attempting to fix the desktop app. This broke lancedb loading in **all** Bun SEA environments — `await import()` returns empty `{}` just like the original static ESM import bug.

## Fix

Simple `createRequire` — proven to work on:
- OpenCode Terminal CLI (all versions)
- OpenCode Desktop v1.3.7

The desktop v1.3.8+ native module loading issue is an upstream OpenCode bug (anomalyco/opencode#20623), not fixable on our side.

Fixes #147
Related: #141, #142, #144, #145