### PR TITLE
chore(deps): fix @hono/node-server alert #19 — bump override to >=1.19.13

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -45,7 +45,7 @@
     ],
     "overrides": {
       "hono": ">=4.12.18",
-      "@hono/node-server": ">=1.19.10",
+      "@hono/node-server": ">=1.19.13",
       "fast-uri": ">=3.1.2",
       "ip-address": ">=10.2.0",
       "postcss": ">=8.5.14",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   hono: '>=4.12.18'
-  '@hono/node-server': '>=1.19.10'
+  '@hono/node-server': '>=1.19.13'
   fast-uri: '>=3.1.2'
   ip-address: '>=10.2.0'
   postcss: '>=8.5.14'
@@ -425,9 +425,9 @@ packages:
       tailwindcss:
         optional: true
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.2':
+    resolution: {integrity: sha512-tXlTi1h/4V7sDe7i97IVP+9re9ZU7wXZZggnR5ucCRclf1+AX6YhGStrR5w8bLj+3Mlyl0pKfBh9gqTqqnGKfQ==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: '>=4.12.18'
 
@@ -3593,7 +3593,7 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.1
 
-  '@hono/node-server@1.19.11(hono@4.12.18)':
+  '@hono/node-server@2.0.2(hono@4.12.18)':
     dependencies:
       hono: 4.12.18
 
@@ -3773,7 +3773,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.18)
+      '@hono/node-server': 2.0.2(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5


### PR DESCRIPTION
## Summary

Fixes the last remaining Dependabot security alert (#19).

| Package | From | To | Severity | CVE |
|---------|------|----|----------|-----|
| `@hono/node-server` | `1.19.11` | `2.0.2` | Moderate | CVE-2026-39406 |

**Issue:** Middleware bypass via repeated slashes in `serveStatic`. Fixed in `>=1.19.13` per [GHSA-92pp-h63x-v22m](https://github.com/honojs/node-server/security/advisories/GHSA-92pp-h63x-v22m).

The previous override `>=1.19.10` was too loose and locked to `1.19.11` (vulnerable). Updated to `>=1.19.13` — Bun resolved to the latest `2.0.2`.

## Verification

- pnpm install — clean
- pnpm build — 15/15 static pages, TypeScript clean

Closes #19