### PR TITLE
feat(website): allow prosperitypirate.com to embed homepage in iframe

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -13,6 +13,22 @@ const config = {
       },
     ];
   },
+  async headers() {
+    return [
+      {
+        // Allow prosperitypirate.com to embed the homepage in an iframe
+        // for the project showcase on the portfolio site.
+        // Uses modern CSP frame-ancestors (X-Frame-Options is deprecated).
+        source: "/",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: "frame-ancestors 'self' https://prosperitypirate.com https://www.prosperitypirate.com",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 const withMDX = createMDX();


### PR DESCRIPTION
## Summary

Adds a `Content-Security-Policy` header with `frame-ancestors` directive to the codexfi website, allowing the homepage to be embedded as a live iframe preview on [prosperitypirate.com](https://prosperitypirate.com)'s project showcase section.

## What changed

**`website/next.config.mjs`** — Added `headers()` function:

```js
async headers() {
  return [{
    source: "/",
    headers: [{
      key: "Content-Security-Policy",
      value: "frame-ancestors 'self' https://prosperitypirate.com https://www.prosperitypirate.com",
    }],
  }];
}
```

## Why

The prosperitypirate.com portfolio site showcases codexfi as a featured project with a live iframe preview (same pattern used for other projects). Without this header, browsers block the iframe due to Vercel's default clickjacking protection.

## Security notes

- Uses modern `frame-ancestors` CSP directive (not deprecated `X-Frame-Options: ALLOW-FROM`)
- Only allows embedding from `prosperitypirate.com` — no other origins
- Only applies to the homepage (`source: "/"`) — all other routes remain fully protected
- `'self'` is preserved so the site can still embed itself if needed

## Testing

After merging and deploying, the codexfi homepage should load as an iframe preview on prosperitypirate.com's projects section. No other behavior changes.