### PR TITLE
fix(xai): migrate to grok-4.3 with none reasoning effort

### DIFF
--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
         with:
-          model: xai/grok-4-1-fast-non-reasoning
+          model: xai/grok-4.3
           share: false
           prompt: |
             You are triaging a new GitHub issue for the codexfi project.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -229,7 +229,7 @@ When OpenCode truncates the conversation, the `[MEMORY]` block is unaffected (it
 | Provider | Model | Speed | Benchmark | Notes |
 |---|---|---|---|---|
 | **Anthropic** (default) | `claude-haiku-4-5` | ~14s/session | **93.5% avg** (3pp variance) | Most consistent |
-| **xAI** | `grok-4-1-fast-non-reasoning` | ~5s/session | ~86.5% avg (16pp variance) | Fastest, cheapest |
+| **xAI** | `grok-4.3` | ~5s/session | ~86.5% avg (16pp variance) | Fastest, cheapest |
 | **Google** | `gemini-3-flash-preview` | ~21s/session | — | Native JSON mode |
 
 Switch via `EXTRACTION_PROVIDER=xai` (or `anthropic`, `google`). Extraction runs in the background — latency is invisible to users.

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -68,7 +68,7 @@ export const VALID_PROVIDERS = new Set<string>(["anthropic", "xai", "google"]);
  *   3. "anthropic" (default)
  *
  * "anthropic" — Claude Haiku 4.5 via Anthropic Messages API (most consistent)
- * "xai"       — Grok 4.1 Fast via api.x.ai (fastest, higher variance)
+ * "xai"       — Grok 4.3 via api.x.ai (fastest, higher variance)
  * "google"    — Gemini 3 Flash via native generateContent API
  */
 const envProvider = process.env.EXTRACTION_PROVIDER;

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -89,7 +89,7 @@ export const EXTRACTION_PROVIDER: ExtractionProvider =
 // ── Model identifiers ───────────────────────────────────────────────────────────
 
 export const XAI_BASE_URL = "https://api.x.ai/v1";
-export const XAI_EXTRACTION_MODEL = "grok-4-1-fast-non-reasoning";
+export const XAI_EXTRACTION_MODEL = "grok-4.3";
 
 export const GOOGLE_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 export const GOOGLE_EXTRACTION_MODEL = "gemini-3-flash-preview";

--- a/plugin/src/dashboard/html.ts
+++ b/plugin/src/dashboard/html.ts
@@ -822,7 +822,7 @@ const ALL_TYPES = [
 
 const API_LABELS = { xai: "xAI", anthropic: "Anthropic", google: "Google", voyage: "Voyage" };
 const API_MODELS = {
-	xai: "grok-4-fast",
+	xai: "grok-4.3",
 	anthropic: "claude-haiku-4-5",
 	google: "gemini-3-flash",
 	voyage: "voyage-code-3",
@@ -1413,7 +1413,7 @@ function costProvider(api, data) {
 	if (!data) return "";
 	var h = '<div class="cost-provider">';
 	h += '<div class="cost-provider-header">';
-	h += '<span class="cost-provider-name">' + (API_LABELS[api] || api) + ' \\u00b7 ' + (API_MODELS[api] || "") + '</span>';
+	h += '<span class="cost-provider-name">' + (API_LABELS[api] || api) + ' \\u00b7 ' + (data.model || API_MODELS[api] || "") + '</span>';
 	h += '<span class="cost-provider-total cost-' + api + '">' + fmtUSD(data.cost_usd) + '</span>';
 	h += '</div>';
 	h += '<div class="cost-row"><span>calls</span><span class="cost-row-value">' + (data.calls || 0).toLocaleString() + '</span></div>';

--- a/plugin/src/extractor.ts
+++ b/plugin/src/extractor.ts
@@ -68,6 +68,7 @@ async function callXai(system: string, user: string): Promise<string> {
 			],
 			max_tokens: LLM_MAX_TOKENS,
 			temperature: LLM_TEMPERATURE,
+			reasoning_effort: "none",
 		}),
 	});
 

--- a/plugin/src/telemetry.ts
+++ b/plugin/src/telemetry.ts
@@ -17,6 +17,7 @@ import {
 	GOOGLE_PRICE_INPUT_PER_M,
 	GOOGLE_PRICE_OUTPUT_PER_M,
 	VOYAGE_PRICE_PER_M,
+	XAI_EXTRACTION_MODEL,
 	XAI_PRICE_CACHED_PER_M,
 	XAI_PRICE_INPUT_PER_M,
 	XAI_PRICE_OUTPUT_PER_M,
@@ -39,10 +40,10 @@ interface VoyageBucket {
 }
 
 interface LedgerData {
-	xai: CostBucket & { cached_tokens: number };
-	google: CostBucket;
-	anthropic: CostBucket;
-	voyage: VoyageBucket;
+	xai: CostBucket & { cached_tokens: number; model?: string };
+	google: CostBucket & { model?: string };
+	anthropic: CostBucket & { model?: string };
+	voyage: VoyageBucket & { model?: string };
 	total_cost_usd: number;
 	last_updated: string;
 }
@@ -104,6 +105,7 @@ class CostLedger {
 		x.cached_tokens += cachedTokens;
 		x.completion_tokens += completionTokens;
 		x.cost_usd = +(x.cost_usd + cost).toFixed(8);
+		x.model = XAI_EXTRACTION_MODEL;
 		this.updateTotal();
 		await this.save();
 	}
@@ -120,6 +122,7 @@ class CostLedger {
 		g.prompt_tokens += promptTokens;
 		g.completion_tokens += completionTokens;
 		g.cost_usd = +(g.cost_usd + cost).toFixed(8);
+		g.model = GOOGLE_EXTRACTION_MODEL;
 		this.updateTotal();
 		await this.save();
 	}
@@ -136,6 +139,7 @@ class CostLedger {
 		a.prompt_tokens += promptTokens;
 		a.completion_tokens += completionTokens;
 		a.cost_usd = +(a.cost_usd + cost).toFixed(8);
+		a.model = ANTHROPIC_EXTRACTION_MODEL;
 		this.updateTotal();
 		await this.save();
 	}

--- a/plugin/src/telemetry.ts
+++ b/plugin/src/telemetry.ts
@@ -150,6 +150,7 @@ class CostLedger {
 		v.calls++;
 		v.tokens += tokens;
 		v.cost_usd = +(v.cost_usd + cost).toFixed(8);
+		v.model = EMBEDDING_MODEL;
 		this.updateTotal();
 		await this.save();
 	}

--- a/testing/src/unit/telemetry.test.ts
+++ b/testing/src/unit/telemetry.test.ts
@@ -10,6 +10,12 @@ import { tmpdir } from "node:os";
 // We can't directly instantiate CostLedger/ActivityLog since they're exported
 // as singletons. But we CAN test the singletons with fresh temp dirs.
 import { ledger, activityLog } from "../../../plugin/src/telemetry.js";
+import {
+	EMBEDDING_MODEL,
+	XAI_EXTRACTION_MODEL,
+	ANTHROPIC_EXTRACTION_MODEL,
+	GOOGLE_EXTRACTION_MODEL,
+} from "../../../plugin/src/config.js";
 
 let tempDir: string;
 
@@ -42,6 +48,7 @@ describe("CostLedger", () => {
 		// $0.18 per M tokens
 		expect(snap.voyage.cost_usd).toBeCloseTo(0.18, 4);
 		expect(snap.total_cost_usd).toBeCloseTo(0.18, 4);
+		expect(snap.voyage.model).toBe(EMBEDDING_MODEL);
 	});
 
 	test("records Anthropic costs correctly", async () => {
@@ -52,6 +59,7 @@ describe("CostLedger", () => {
 		expect(snap.anthropic.completion_tokens).toBe(10_000);
 		// $1.00/M input + $5.00/M output = $0.10 + $0.05 = $0.15
 		expect(snap.anthropic.cost_usd).toBeCloseTo(0.15, 4);
+		expect(snap.anthropic.model).toBe(ANTHROPIC_EXTRACTION_MODEL);
 	});
 
 	test("records xAI costs with cached tokens", async () => {
@@ -64,6 +72,16 @@ describe("CostLedger", () => {
 		expect(snap.xai.completion_tokens).toBe(2_000);
 		// (10k-5k)*0.20/M + 5k*0.05/M + 2k*0.50/M = 0.001 + 0.00025 + 0.001 = 0.00225
 		expect(snap.xai.cost_usd).toBeCloseTo(0.00225, 6);
+		expect(snap.xai.model).toBe(XAI_EXTRACTION_MODEL);
+	});
+
+	test("records Google costs correctly", async () => {
+		await ledger.recordGoogle(50_000, 5_000);
+		const snap = ledger.snapshot();
+		expect(snap.google.calls).toBe(1);
+		expect(snap.google.prompt_tokens).toBe(50_000);
+		expect(snap.google.completion_tokens).toBe(5_000);
+		expect(snap.google.model).toBe(GOOGLE_EXTRACTION_MODEL);
 	});
 
 	test("accumulates multiple calls", async () => {

--- a/website/components/svg/docs/docs-provider-speed.tsx
+++ b/website/components/svg/docs/docs-provider-speed.tsx
@@ -56,7 +56,7 @@ export function DocsProviderSpeed() {
       {/* Card 2: xAI */}
       <rect x="185" y="15" width="150" height="130" rx="10" className="fill-card stroke-border" strokeWidth="1.5" />
       <text x="200" y="45" fontSize="12" fontWeight="600" fontFamily="var(--font-mono, monospace)" className="fill-foreground">xAI</text>
-      <text x="200" y="59" fontSize="9" fontFamily="var(--font-mono, monospace)" className="fill-muted-foreground">grok-4-1-fast</text>
+      <text x="200" y="59" fontSize="9" fontFamily="var(--font-mono, monospace)" className="fill-muted-foreground">grok-4.3</text>
       <text x="200" y="90" fontSize="22" fontWeight="700" fontFamily="var(--font-mono, monospace)" fill="#4ade80">~5s</text>
       
       {/* Badge */}

--- a/website/content/docs/configuration.mdx
+++ b/website/content/docs/configuration.mdx
@@ -43,7 +43,7 @@ The config file lives at `~/.codexfi/codexfi.jsonc`. It is created automatically
 |-----|----------|---------|
 | `voyageApiKey` | Yes | Voyage AI embeddings (`voyage-code-3`) |
 | `anthropicApiKey` | One of three | Extraction via Claude Haiku 4.5 (default) |
-| `xaiApiKey` | One of three | Extraction via Grok 4.1 Fast |
+| `xaiApiKey` | One of three | Extraction via Grok 4.3 |
 | `googleApiKey` | One of three | Extraction via Gemini 3 Flash |
 
 At minimum, you need `voyageApiKey` plus one extraction provider key.
@@ -79,7 +79,7 @@ You can also set the provider during `codexfi install` (interactive prompt or `-
 | Provider | Model | Speed | Notes |
 |----------|-------|-------|-------|
 | `anthropic` (default) | `claude-haiku-4-5` | ~14s/session | Most consistent extraction |
-| `xai` | `grok-4-1-fast-non-reasoning` | ~5s/session | Fastest, cheapest |
+| `xai` | `grok-4.3` | ~5s/session | Fastest, cheapest |
 | `google` | `gemini-3-flash-preview` | ~21s/session | Native JSON response mode |
 
 The plugin falls back through all configured providers automatically. If the primary fails, it tries the next one in the fallback order: `anthropic` > `xai` > `google`.

--- a/website/content/docs/how-it-works/extraction.mdx
+++ b/website/content/docs/how-it-works/extraction.mdx
@@ -115,7 +115,7 @@ Set your provider via `"extractionProvider"` in `codexfi.jsonc` — see [Configu
 
 ### xAI
 
-- **Model**: `grok-4-1-fast-non-reasoning`
+- **Model**: `grok-4.3`
 - **Speed**: ~5 seconds per session
 - **Notes**: Fastest and cheapest. Slightly higher variance in extraction quality.
 


### PR DESCRIPTION
## Summary

xAI deprecated several Grok models on May 15, 2026 (including `grok-4-1-fast-non-reasoning` and `grok-4-fast-non-reasoning`). This PR migrates codexfi to `grok-4.3` with explicit `reasoning_effort: none` — matching the previous non-reasoning behavior — and fixes the dashboard cost summary to show the actual model name dynamically instead of a hardcoded label.

## What changed

| File | Change |
|------|--------|
| `plugin/src/config.ts` | `XAI_EXTRACTION_MODEL` → `grok-4.3` |
| `plugin/src/extractor.ts` | Added `reasoning_effort: "none"` to xAI API request body |
| `.github/workflows/opencode-triage.yml` | Triage bot model → `xai/grok-4.3` |
| `plugin/README.md` | Updated provider comparison table |
| `plugin/src/telemetry.ts` | `LedgerData` now tracks `model` field per provider; set on every `record*` call |
| `plugin/src/dashboard/html.ts` | Cost summary header reads `data.model` from DB instead of hardcoded `API_MODELS` constant |

## Why `reasoning_effort: none`

Per xAI's migration guide, requests to non-reasoning slugs are redirected to `grok-4.3` with `none` reasoning effort. Setting it explicitly:
- Avoids any ambiguity in how xAI applies the default
- Prevents accidental billing for reasoning tokens
- Matches the behaviour of the deprecated `grok-4-1-fast-non-reasoning` model exactly

## Dashboard improvement

Previously the cost summary showed a hardcoded `grok-4-fast` label regardless of which model was actually in use. Now the label is read from the cost ledger DB and updates automatically whenever the extraction model changes — no code change needed in future migrations.

## Testing

Tested locally with `extractionProvider: xai` — confirmed `grok-4.3` appearing in dashboard API Activity and cost summary label updating correctly.

## Related

xAI model retirement notice: https://docs.x.ai/developers/migration/may-15-retirement