### PR TITLE
feat(website): add localhost:3000 to iframe frame-ancestors for dev preview

### DIFF
--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -23,7 +23,7 @@ const config = {
         headers: [
           {
             key: "Content-Security-Policy",
-            value: "frame-ancestors 'self' https://prosperitypirate.com https://www.prosperitypirate.com",
+            value: "frame-ancestors 'self' https://prosperitypirate.com https://www.prosperitypirate.com http://localhost:3000",
           },
         ],
       },


### PR DESCRIPTION
## Summary

Extends the CSP `frame-ancestors` header (added in #188) to also allow `http://localhost:3000`, enabling the codexfi homepage to load as a live iframe preview during local development of prosperitypirate.com.

## What changed

**`website/next.config.mjs`** — Added `http://localhost:3000` to the existing `frame-ancestors` value:

```js
// Before (#188):
value: "frame-ancestors 'self' https://prosperitypirate.com https://www.prosperitypirate.com"

// After (this PR):
value: "frame-ancestors 'self' https://prosperitypirate.com https://www.prosperitypirate.com http://localhost:3000"
```

## Why

When developing prosperitypirate.com locally at `localhost:3000`, the codexfi iframe preview was blocked because `localhost:3000` wasn't in the allowlist. This PR adds it so developers can see the live preview during local development without needing to deploy first.

## Security notes

- `localhost:3000` is a development-only origin — no real security risk
- Production allowlist (`prosperitypirate.com`) was established in #188
- Only the homepage (`source: "/"`) is affected — all other routes remain protected

## Testing

After merging and deploying, refresh `localhost:3000` on prosperitypirate.com and scroll to the Projects section — the codexfi iframe preview should load.