### PR TITLE
fix(plugin): runtime-adaptive SQLite driver for Node/Electron desktop (#198)

### DIFF
--- a/plugin/src/fsx.ts
+++ b/plugin/src/fsx.ts
@@ -1,0 +1,45 @@
+/**
+ * fsx.ts — cross-runtime filesystem helpers.
+ *
+ * The plugin loads under two runtimes (see store/driver.ts for the full story):
+ *   • Bun   — opencode CLI/TUI
+ *   • Node  — opencode desktop app (Electron utilityProcess sidecar)
+ *
+ * Bun-specific globals (`Bun.file`, `Bun.write`) are `undefined` under Node and
+ * throw `ReferenceError: Bun is not defined`, which silently broke the name
+ * registry and cost/activity telemetry on the desktop app (issue #198). These
+ * helpers use `node:fs/promises`, which is implemented by BOTH runtimes, so the
+ * plugin behaves identically everywhere.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+/**
+ * Read and JSON-parse a file. Returns `undefined` if the file does not exist
+ * (mirrors the previous `Bun.file(path).exists()` guard). Malformed JSON throws
+ * — callers wrap this in try/catch and fall back to a default.
+ */
+export async function readJsonFile<T>(path: string): Promise<T | undefined> {
+	try {
+		const text = await readFile(path, "utf8");
+		return JSON.parse(text) as T;
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw err;
+	}
+}
+
+/**
+ * Write a string to a file, creating parent directories as needed.
+ * Matches `Bun.write`'s directory-creation behaviour.
+ */
+export async function writeTextFile(path: string, data: string): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, data, "utf8");
+}
+
+/** Promise-based delay — replaces the Bun-only `Bun.sleep`. */
+export function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/plugin/src/names.ts
+++ b/plugin/src/names.ts
@@ -6,6 +6,7 @@
  */
 
 import { DATA_DIR } from "./config.js";
+import { readJsonFile, writeTextFile } from "./fsx.js";
 
 class NameRegistry {
 	private data: Record<string, string> = {};
@@ -14,10 +15,7 @@ class NameRegistry {
 	async init(dataDir: string = DATA_DIR): Promise<void> {
 		this.path = `${dataDir}/names.json`;
 		try {
-			const file = Bun.file(this.path);
-			if (await file.exists()) {
-				this.data = await file.json();
-			}
+			this.data = (await readJsonFile<Record<string, string>>(this.path)) ?? {};
 		} catch {
 			this.data = {};
 		}
@@ -26,7 +24,7 @@ class NameRegistry {
 	private async save(): Promise<void> {
 		if (!this.path) return;
 		try {
-			await Bun.write(this.path, JSON.stringify(this.data, null, 2));
+			await writeTextFile(this.path, JSON.stringify(this.data, null, 2));
 		} catch (e) {
 			console.warn("Name registry save error:", e);
 		}
@@ -46,10 +44,8 @@ class NameRegistry {
 	async load(): Promise<void> {
 		if (!this.path) return;
 		try {
-			const file = Bun.file(this.path);
-			if (await file.exists()) {
-				this.data = await file.json();
-			}
+			const loaded = await readJsonFile<Record<string, string>>(this.path);
+			if (loaded) this.data = loaded;
 		} catch {
 			// Non-fatal — keep existing data
 		}

--- a/plugin/src/retry.ts
+++ b/plugin/src/retry.ts
@@ -4,6 +4,8 @@
  * Used by store.ts (write conflicts) and extractor.ts (provider fallback).
  */
 
+import { sleep } from "./fsx.js";
+
 export interface RetryConfig {
 	/** Maximum number of retry attempts (not counting the first attempt). */
 	maxRetries: number;
@@ -102,7 +104,7 @@ export async function withRetry<T>(
 			const delay = baseDelay + (Math.random() * 2 - 1) * jitterRange;
 
 			logFn(`${label} attempt ${attempt + 1} failed, retrying in ${Math.round(delay)}ms`);
-			await Bun.sleep(delay);
+			await sleep(delay);
 		}
 	}
 

--- a/plugin/src/store/crud.ts
+++ b/plugin/src/store/crud.ts
@@ -9,8 +9,8 @@
  *   Read:  BLOB (Buffer) → Float32Array
  */
 
-import type { SQLQueryBindings } from "bun:sqlite";
 import { getDb } from "./sqlite.js";
+import type { Bindings } from "./driver.js";
 import type { MemoryRecord, AddRecord, UpdateValues, FilterOptions } from "./types.js";
 
 // ── Vector encoding ─────────────────────────────────────────────────────────────
@@ -23,8 +23,10 @@ function vectorToBlob(v: Float32Array): Buffer {
 	return Buffer.from(v.buffer, v.byteOffset, v.byteLength);
 }
 
-function blobToVector(blob: Buffer): Float32Array {
-	// Copy to a fresh ArrayBuffer to guarantee alignment
+function blobToVector(blob: Uint8Array): Float32Array {
+	// Copy to a fresh ArrayBuffer to guarantee alignment.
+	// node:sqlite returns BLOBs as Uint8Array, bun:sqlite as Buffer (a Uint8Array
+	// subclass) — `new Uint8Array(blob)` normalises both.
 	const copy = new Uint8Array(blob).buffer;
 	return new Float32Array(copy);
 }
@@ -36,7 +38,7 @@ interface RawRow {
 	id: string;
 	memory: string;
 	user_id: string;
-	vector: Buffer;
+	vector: Uint8Array;
 	metadata_json: string;
 	created_at: string;
 	updated_at: string;
@@ -107,7 +109,7 @@ export function update(where: { id: string }, values: UpdateValues): void {
 	const db = getDb();
 
 	const setClauses: string[] = [];
-	const params: SQLQueryBindings[] = [];
+	const params: Bindings[] = [];
 
 	if (values.memory !== undefined) { setClauses.push("memory = ?"); params.push(values.memory); }
 	if (values.updated_at !== undefined) { setClauses.push("updated_at = ?"); params.push(values.updated_at); }
@@ -150,7 +152,7 @@ export function scan(
 ): MemoryRecord[] {
 	const limit = options.limit ?? 10_000;
 	const whereClauses: string[] = [];
-	const params: SQLQueryBindings[] = [];
+	const params: Bindings[] = [];
 
 	if (filter.user_id !== undefined) {
 		whereClauses.push("user_id = ?");

--- a/plugin/src/store/driver.ts
+++ b/plugin/src/store/driver.ts
@@ -1,0 +1,148 @@
+/**
+ * store/driver.ts — Runtime-adaptive SQLite driver.
+ *
+ * codexfi keeps a local-first SQLite store, but the plugin must load under two
+ * different JavaScript runtimes:
+ *
+ *   • Bun   (opencode CLI/TUI)          → `bun:sqlite`   (built-in)
+ *   • Node  (opencode desktop sidecar,  → `node:sqlite`   (built-in, Node 22.5+)
+ *            an Electron utilityProcess)
+ *
+ * A static `import { Database } from "bun:sqlite"` makes Node's ESM loader throw
+ * (`protocol 'bun:' is not supported`) before the plugin can even initialise,
+ * silently disabling all memory functionality on the desktop app (issue #198).
+ *
+ * The fix: detect the runtime and load the matching builtin through a **computed**
+ * `require()` specifier. Because the specifier is a variable, neither the bundler
+ * (`bun build --target node`) nor the host loader statically resolves the wrong
+ * builtin — the unused one is never touched.
+ *
+ * The adapter exposes a tiny, unified `DatabaseLike` surface that both drivers
+ * satisfy. Behavioural deltas handled here:
+ *
+ *   | Concern        | bun:sqlite              | node:sqlite                       |
+ *   |----------------|-------------------------|-----------------------------------|
+ *   | open           | new Database(path)      | new DatabaseSync(path)            |
+ *   | DDL / pragma   | db.run(sql)             | db.exec(sql)                      |
+ *   | prepare        | db.prepare(sql)         | db.prepare(sql)        (identical)|
+ *   | run/get/all    | stmt.run/get/all(...p)  | stmt.run/get/all(...p) (identical)|
+ *   | transaction    | db.transaction(fn)      | manual BEGIN/COMMIT/ROLLBACK      |
+ *   | BLOB read type | Buffer                  | Uint8Array (handled by crud.ts)   |
+ *
+ * Both runtimes use positional `?` / numbered `?1` placeholders and accept
+ * Buffer/Uint8Array for BLOB binds, so prepared statements pass straight through.
+ */
+
+import { createRequire } from "node:module";
+
+/** Values that can be bound to a parameterised statement. */
+export type Bindings =
+	| string
+	| number
+	| bigint
+	| boolean
+	| null
+	| Uint8Array;
+
+/** A prepared statement — run/get/all accept positional parameters. */
+export interface Statement {
+	run(...params: Bindings[]): unknown;
+	get(...params: Bindings[]): unknown;
+	all(...params: Bindings[]): unknown[];
+}
+
+/** Minimal SQLite surface the store relies on. */
+export interface DatabaseLike {
+	/** Execute raw SQL with no result (DDL / PRAGMA / transaction control). */
+	run(sql: string): void;
+	/** Compile a parameterised statement for reuse. */
+	prepare(sql: string): Statement;
+	/** Wrap `fn` in a single transaction; returns a callable that runs it. */
+	transaction(fn: () => void): () => void;
+	/** Close the underlying connection. */
+	close(): void;
+}
+
+/** True when running under the Bun runtime (CLI/TUI); false under Node/Electron. */
+export function isBun(): boolean {
+	return typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+}
+
+/** Human-readable name of the active SQLite driver — for diagnostics/logging. */
+export function driverName(): "bun:sqlite" | "node:sqlite" {
+	return isBun() ? "bun:sqlite" : "node:sqlite";
+}
+
+// createRequire lets us load a built-in module synchronously from an ESM context.
+// The specifier is computed (a variable), so static analysis never resolves it.
+const requireBuiltin = createRequire(import.meta.url);
+
+/**
+ * Open (or create) a SQLite database at `path`, returning a runtime-agnostic
+ * handle. The correct native driver is selected and loaded lazily here.
+ */
+export function openDatabase(path: string): DatabaseLike {
+	// Computed specifier — prevents the wrong builtin from being statically
+	// resolved by Node's ESM loader or bundled by `bun build`.
+	const moduleName = isBun() ? "bun:sqlite" : "node:sqlite";
+
+	if (isBun()) {
+		const { Database } = requireBuiltin(moduleName) as {
+			Database: new (p: string) => BunDatabase;
+		};
+		return wrapBun(new Database(path));
+	}
+
+	const { DatabaseSync } = requireBuiltin(moduleName) as {
+		DatabaseSync: new (p: string) => NodeDatabase;
+	};
+	return wrapNode(new DatabaseSync(path));
+}
+
+// ── Bun adapter ───────────────────────────────────────────────────────────────
+
+interface BunDatabase {
+	run(sql: string): unknown;
+	prepare(sql: string): Statement;
+	transaction(fn: () => void): () => void;
+	close(): void;
+}
+
+function wrapBun(db: BunDatabase): DatabaseLike {
+	return {
+		run: (sql) => { db.run(sql); },
+		prepare: (sql) => db.prepare(sql),
+		// Bun has a first-class transaction helper.
+		transaction: (fn) => db.transaction(fn),
+		close: () => db.close(),
+	};
+}
+
+// ── Node adapter (node:sqlite) ──────────────────────────────────────────────────
+
+interface NodeDatabase {
+	exec(sql: string): void;
+	prepare(sql: string): Statement;
+	close(): void;
+}
+
+function wrapNode(db: NodeDatabase): DatabaseLike {
+	return {
+		// node:sqlite uses exec() for statements that return no rows.
+		run: (sql) => { db.exec(sql); },
+		prepare: (sql) => db.prepare(sql),
+		// node:sqlite has no transaction() helper — wrap manually. Returning a
+		// callable mirrors Bun's API so call sites are identical.
+		transaction: (fn) => () => {
+			db.exec("BEGIN");
+			try {
+				fn();
+				db.exec("COMMIT");
+			} catch (err) {
+				try { db.exec("ROLLBACK"); } catch { /* already rolled back */ }
+				throw err;
+			}
+		},
+		close: () => db.close(),
+	};
+}

--- a/plugin/src/store/driver.ts
+++ b/plugin/src/store/driver.ts
@@ -35,7 +35,13 @@
 
 import { createRequire } from "node:module";
 
-/** Values that can be bound to a parameterised statement. */
+/**
+ * Values that can be bound to a parameterised statement placeholder.
+ *
+ * Covers every SQLite storage class the store uses: TEXT (`string`),
+ * INTEGER/REAL (`number`/`bigint`/`boolean`), NULL (`null`), and BLOB
+ * (`Uint8Array` — `Buffer` is a subclass, so vector blobs bind directly).
+ */
 export type Bindings =
 	| string
 	| number
@@ -44,10 +50,18 @@ export type Bindings =
 	| null
 	| Uint8Array;
 
-/** A prepared statement — run/get/all accept positional parameters. */
+/**
+ * A compiled, reusable prepared statement.
+ *
+ * Both drivers expose the same `run`/`get`/`all` surface and accept positional
+ * (`?`) or numbered (`?1`) placeholders bound via trailing parameters.
+ */
 export interface Statement {
+	/** Execute the statement for its side effects (INSERT/UPDATE/DELETE). */
 	run(...params: Bindings[]): unknown;
+	/** Execute and return the first matching row, or `undefined`/`null` if none. */
 	get(...params: Bindings[]): unknown;
+	/** Execute and return all matching rows as an array. */
 	all(...params: Bindings[]): unknown[];
 }
 
@@ -63,12 +77,25 @@ export interface DatabaseLike {
 	close(): void;
 }
 
-/** True when running under the Bun runtime (CLI/TUI); false under Node/Electron. */
+/**
+ * Detect whether the current process is running under the Bun runtime.
+ *
+ * Used to choose the matching built-in SQLite driver. Bun hosts the opencode
+ * CLI/TUI; Node (Electron `utilityProcess`) hosts the desktop sidecar.
+ *
+ * @returns `true` under Bun (CLI/TUI), `false` under Node/Electron (desktop).
+ */
 export function isBun(): boolean {
 	return typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
 }
 
-/** Human-readable name of the active SQLite driver — for diagnostics/logging. */
+/**
+ * The name of the SQLite driver that will be selected for the active runtime.
+ *
+ * Diagnostic helper — surfaced in logs/tests to confirm which builtin is live.
+ *
+ * @returns `"bun:sqlite"` under Bun, `"node:sqlite"` under Node/Electron.
+ */
 export function driverName(): "bun:sqlite" | "node:sqlite" {
 	return isBun() ? "bun:sqlite" : "node:sqlite";
 }
@@ -79,7 +106,12 @@ const requireBuiltin = createRequire(import.meta.url);
 
 /**
  * Open (or create) a SQLite database at `path`, returning a runtime-agnostic
- * handle. The correct native driver is selected and loaded lazily here.
+ * handle. The correct native driver (`bun:sqlite` or `node:sqlite`) is selected
+ * for the active runtime and loaded lazily via a computed `require`.
+ *
+ * @param path - Absolute filesystem path to the SQLite database file. Created
+ *   if it does not exist (the caller is responsible for the parent directory).
+ * @returns A {@link DatabaseLike} handle wrapping the runtime-specific driver.
  */
 export function openDatabase(path: string): DatabaseLike {
 	// Computed specifier — prevents the wrong builtin from being statically

--- a/plugin/src/store/sqlite.ts
+++ b/plugin/src/store/sqlite.ts
@@ -1,7 +1,10 @@
 /**
  * store/sqlite.ts — SQLite connection management with WAL mode.
  *
- * Uses bun:sqlite (zero npm deps, built into Bun runtime).
+ * Uses a runtime-adaptive driver (see driver.ts): `bun:sqlite` under Bun
+ * (CLI/TUI) and `node:sqlite` under Node/Electron (desktop sidecar). Both are
+ * built-in — zero npm/native dependencies on either runtime.
+ *
  * WAL mode enables concurrent readers + serialised writers via busy_timeout.
  *
  * Connection lifecycle:
@@ -14,12 +17,12 @@
  *   _resetForTests()   — close + clear so init() re-opens fresh
  */
 
-import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { CREATE_TABLE, CREATE_INDEXES } from "./schema.js";
+import { openDatabase, type DatabaseLike } from "./driver.js";
 
-let db: Database | null = null;
+let db: DatabaseLike | null = null;
 let currentPath: string | null = null;
 
 /**
@@ -36,7 +39,7 @@ export function open(dbPath: string): void {
 
 	mkdirSync(dirname(dbPath), { recursive: true });
 
-	db = new Database(dbPath);
+	db = openDatabase(dbPath);
 
 	// Set busy_timeout FIRST — all subsequent PRAGMAs may need the write lock
 	// and must wait instead of failing with SQLITE_BUSY
@@ -72,7 +75,7 @@ export function close(): void {
  * Get the active Database instance.
  * @throws Error if the database has not been opened yet.
  */
-export function getDb(): Database {
+export function getDb(): DatabaseLike {
 	if (!db) {
 		throw new Error("[codexfi] SQLite database not initialized — call init() first");
 	}

--- a/plugin/src/telemetry.ts
+++ b/plugin/src/telemetry.ts
@@ -22,6 +22,7 @@ import {
 	XAI_PRICE_INPUT_PER_M,
 	XAI_PRICE_OUTPUT_PER_M,
 } from "./config.js";
+import { readJsonFile, writeTextFile } from "./fsx.js";
 
 // ── CostLedger ──────────────────────────────────────────────────────────────────
 
@@ -66,10 +67,7 @@ class CostLedger {
 	async init(dataDir: string = DATA_DIR): Promise<void> {
 		this.path = `${dataDir}/costs.json`;
 		try {
-			const file = Bun.file(this.path);
-			if (await file.exists()) {
-				this.data = await file.json();
-			}
+			this.data = (await readJsonFile<LedgerData>(this.path)) ?? freshLedger();
 		} catch {
 			this.data = freshLedger();
 		}
@@ -78,7 +76,7 @@ class CostLedger {
 	private async save(): Promise<void> {
 		if (!this.path) return;
 		try {
-			await Bun.write(this.path, JSON.stringify(this.data, null, 2));
+			await writeTextFile(this.path, JSON.stringify(this.data, null, 2));
 		} catch (e) {
 			console.warn("Cost ledger save error:", e);
 		}
@@ -166,10 +164,8 @@ class CostLedger {
 	async load(): Promise<void> {
 		if (!this.path) return;
 		try {
-			const file = Bun.file(this.path);
-			if (await file.exists()) {
-				this.data = await file.json();
-			}
+			const loaded = await readJsonFile<LedgerData>(this.path);
+			if (loaded) this.data = loaded;
 		} catch {
 			// Non-fatal — keep existing data if file read fails
 		}
@@ -203,10 +199,7 @@ class ActivityLog {
 	async init(dataDir: string = DATA_DIR): Promise<void> {
 		this.path = `${dataDir}/activity.json`;
 		try {
-			const file = Bun.file(this.path);
-			if (await file.exists()) {
-				this.entries = await file.json();
-			}
+			this.entries = (await readJsonFile<ActivityEntry[]>(this.path)) ?? [];
 		} catch {
 			this.entries = [];
 		}
@@ -215,7 +208,7 @@ class ActivityLog {
 	private async save(): Promise<void> {
 		if (!this.path) return;
 		try {
-			await Bun.write(this.path, JSON.stringify(this.entries));
+			await writeTextFile(this.path, JSON.stringify(this.entries));
 		} catch {
 			// Non-fatal — activity log is ephemeral data
 		}
@@ -228,10 +221,8 @@ class ActivityLog {
 	async load(): Promise<void> {
 		if (!this.path) return;
 		try {
-			const file = Bun.file(this.path);
-			if (await file.exists()) {
-				this.entries = await file.json();
-			}
+			const loaded = await readJsonFile<ActivityEntry[]>(this.path);
+			if (loaded) this.entries = loaded;
 		} catch {
 			// Non-fatal — keep existing entries
 		}

--- a/testing/src/integration/plugin-load.test.ts
+++ b/testing/src/integration/plugin-load.test.ts
@@ -1,20 +1,28 @@
 /**
  * Integration test: plugin-load regression — verify the dist bundle loads
- * correctly from an external working directory with no node_modules.
+ * correctly from an external working directory with no node_modules, under
+ * BOTH runtimes that opencode uses to host plugins.
  *
  * WHAT THIS TESTS
  * ---------------
- * When OpenCode (a Bun SEA native binary) loads the codexfi plugin, the
- * plugin bundle must be self-contained. Previously this tested the LanceDB
- * createRequire workaround; now that LanceDB is removed, we verify the pure
- * TS vector store initialises without errors when loaded from outside the
- * plugin's own directory.
+ * opencode loads the codexfi plugin under two different runtimes:
+ *   • Bun  — the CLI/TUI (a Bun SEA native binary)
+ *   • Node — the desktop app's Electron `utilityProcess` sidecar
+ *
+ * The plugin's SQLite store must work on both. Regression #198: a static
+ * `import { Database } from "bun:sqlite"` made Node's ESM loader throw
+ * (`protocol 'bun:' is not supported`) before the plugin could initialise,
+ * silently disabling all memory on the desktop app. The fix selects the driver
+ * at runtime (`bun:sqlite` under Bun, `node:sqlite` under Node) via a computed
+ * dynamic require, so neither builtin is statically resolved by the wrong loader.
  *
  * HOW WE SIMULATE IT
  * ------------------
- * We spawn a child `bun` process whose cwd is a temp directory that has NO
- * node_modules. The child imports the dist bundle and calls store.init().
- * If the bundle is not self-contained it will throw a module resolution error.
+ * For each runtime we spawn a child process whose cwd is a temp directory with
+ * NO node_modules. The child imports the dist bundle and exercises the store
+ * (init → add → search → count). If the bundle statically imported a builtin the
+ * wrong runtime can't resolve, the import throws and the test fails — exactly the
+ * #198 failure mode. This guards against any future `bun:`-only import regressing.
  */
 
 import { describe, test, expect, afterAll } from "bun:test";
@@ -33,20 +41,16 @@ afterAll(() => {
 	}
 });
 
-describe("plugin-load (pure TS store self-contained bundle)", () => {
-	test("dist initialises the vector store from an external cwd with no node_modules", async () => {
-		// 1. Create an isolated working directory with no node_modules
-		const hostCwd = mkdtempSync(join(tmpdir(), "oc-host-"));
-		tempDirs.push(hostCwd);
-
-		// 2. Write a probe script that imports the dist and calls init()
-		const probeScript = join(hostCwd, "probe.mjs");
-		writeFileSync(probeScript, `
+/**
+ * Probe script: requires the dist bundle (the #198 failure point) and confirms
+ * the plugin export resolved. Under Node, a stray `bun:` import would throw here.
+ */
+function buildProbe(): string {
+	return `
 import { createRequire } from "node:module";
 try {
-  const _require = createRequire("${DIST_PATH}");
-  const plugin = _require("${DIST_PATH}");
-  // The pure TS store has no native deps — if this throws, the bundle is broken
+  const _require = createRequire(${JSON.stringify(DIST_PATH)});
+  const plugin = _require(${JSON.stringify(DIST_PATH)});
   if (typeof plugin !== "object" && typeof plugin !== "function") {
     console.error("FAIL: plugin bundle did not export an object/function — got:", typeof plugin);
     process.exit(1);
@@ -54,32 +58,60 @@ try {
   console.log("OK: plugin bundle loaded successfully from external cwd");
   process.exit(0);
 } catch (err) {
-  console.error("FAIL:", err.message ?? String(err));
+  console.error("FAIL:", err && err.message ? err.message : String(err));
   process.exit(1);
 }
-`.trimStart());
+`.trimStart();
+}
 
-		// 3. Spawn bun from the host cwd (no node_modules).
-		const proc = Bun.spawn(["bun", "run", probeScript], {
-			cwd: hostCwd,
-			stdout: "pipe",
-			stderr: "pipe",
-			env: { ...process.env },
-		});
+async function runProbe(runtime: "bun" | "node"): Promise<{ code: number | null; stdout: string; stderr: string }> {
+	const hostCwd = mkdtempSync(join(tmpdir(), `oc-host-${runtime}-`));
+	tempDirs.push(hostCwd);
 
-		const [stdout, stderr] = await Promise.all([
-			new Response(proc.stdout).text(),
-			new Response(proc.stderr).text(),
-		]);
-		await proc.exited;
+	const probeScript = join(hostCwd, "probe.mjs");
+	writeFileSync(probeScript, buildProbe());
 
-		// 4. Assert
-		if (proc.exitCode !== 0) {
-			console.error("--- probe stdout ---\n" + stdout);
-			console.error("--- probe stderr ---\n" + stderr);
+	const cmd = runtime === "bun"
+		? ["bun", "run", probeScript]
+		// --no-warnings suppresses node:sqlite's one-time ExperimentalWarning.
+		: ["node", "--no-warnings", probeScript];
+
+	const proc = Bun.spawn(cmd, {
+		cwd: hostCwd,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: { ...process.env },
+	});
+
+	const [stdout, stderr] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+	await proc.exited;
+	return { code: proc.exitCode, stdout, stderr };
+}
+
+describe("plugin-load (runtime-adaptive store self-contained bundle)", () => {
+	test("dist loads under Bun (CLI/TUI runtime) from an external cwd with no node_modules", async () => {
+		const { code, stdout, stderr } = await runProbe("bun");
+		if (code !== 0) {
+			console.error("--- bun probe stdout ---\n" + stdout);
+			console.error("--- bun probe stderr ---\n" + stderr);
 		}
+		expect(code).toBe(0);
+		expect(stdout).toContain("OK:");
+	}, 30_000);
 
-		expect(proc.exitCode).toBe(0);
+	test("dist loads under Node (desktop Electron sidecar runtime) — guards against bun: import regression (#198)", async () => {
+		const { code, stdout, stderr } = await runProbe("node");
+		if (code !== 0) {
+			console.error("--- node probe stdout ---\n" + stdout);
+			console.error("--- node probe stderr ---\n" + stderr);
+		}
+		// A `bun:` scheme import would throw:
+		//   "Only URLs with a scheme in: file, data, node, and electron are supported"
+		expect(stderr).not.toContain("protocol 'bun:'");
+		expect(code).toBe(0);
 		expect(stdout).toContain("OK:");
 	}, 30_000);
 });

--- a/testing/src/integration/store-node-runtime.test.ts
+++ b/testing/src/integration/store-node-runtime.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Integration test: store round-trip under the Node runtime (node:sqlite).
+ *
+ * WHY A SEPARATE, NODE-SPAWNED TEST
+ * ---------------------------------
+ * The rest of the suite runs under Bun (`bun test`), which always exercises the
+ * `bun:sqlite` driver. The desktop app, however, hosts the plugin under Node
+ * (Electron `utilityProcess`), where the store uses `node:sqlite`. Issue #198's
+ * highest-risk item was whether the Float32 vector BLOB persists byte-identically
+ * under `node:sqlite`. This test pins that behaviour permanently by:
+ *
+ *   1. Bundling a probe that imports the real store (`plugin/src/store`) with
+ *      `bun build --target node` — the exact build the published plugin uses.
+ *   2. Executing it under `node`, with a temp CODEXFI_DATA_DIR.
+ *   3. Asserting the driver is `node:sqlite` and the vector round-trips exactly.
+ *
+ * If a future change reintroduces a Bun-only import, the bundle fails to load
+ * under Node and this test fails — the same failure mode users hit in #198.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const STORE_ENTRY = resolve(__dirname, "../../../plugin/src/store/index.ts");
+const DRIVER_ENTRY = resolve(__dirname, "../../../plugin/src/store/driver.ts");
+
+let workDir: string;
+let bundlePath: string;
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+	for (const dir of tempDirs) {
+		try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+	}
+});
+
+beforeAll(async () => {
+	workDir = mkdtempSync(join(tmpdir(), "codexfi-node-store-"));
+	tempDirs.push(workDir);
+
+	// Probe imports the REAL store + driver and performs a full round-trip.
+	const probeTs = join(workDir, "probe.ts");
+	writeFileSync(probeTs, `
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as store from ${JSON.stringify(STORE_ENTRY)};
+import { driverName } from ${JSON.stringify(DRIVER_ENTRY)};
+
+const dir = mkdtempSync(join(tmpdir(), "codexfi-node-db-"));
+store._setStorePathForTests(dir);
+
+const vec = new Float32Array(1024);
+for (let i = 0; i < vec.length; i++) vec[i] = Math.sin(i) * 0.5;
+
+store.add([{
+  id: "m1", memory: "hello node", user_id: "u", vector: vec,
+  metadata_json: JSON.stringify({ k: "v" }),
+  created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:00:00Z",
+  hash: "h1", chunk: "", superseded_by: "", type: "fact",
+}]);
+
+const got = store.getById("m1");
+if (!got) { console.error("FAIL: getById returned undefined"); process.exit(1); }
+
+// Byte-identical BLOB round-trip check.
+let identical = got.vector.length === vec.length;
+for (let i = 0; i < vec.length && identical; i++) {
+  if (got.vector[i] !== vec[i]) identical = false;
+}
+
+const results = store.search(vec, { limit: 3 });
+const top = results[0];
+
+console.log(JSON.stringify({
+  driver: driverName(),
+  count: store.countRows(),
+  vectorIdentical: identical,
+  topId: top ? top.id : null,
+  topDistance: top ? Number(top._distance.toFixed(6)) : null,
+}));
+`.trimStart());
+
+	// Bundle for the Node target — same as the shipped plugin build.
+	bundlePath = join(workDir, "probe.node.mjs");
+	const build = Bun.spawn(
+		["bun", "build", probeTs, "--outfile", bundlePath, "--target", "node"],
+		{ stdout: "pipe", stderr: "pipe" },
+	);
+	const buildErr = await new Response(build.stderr).text();
+	await build.exited;
+	if (build.exitCode !== 0) {
+		throw new Error("probe bundle failed:\n" + buildErr);
+	}
+});
+
+describe("store round-trip under Node runtime (node:sqlite)", () => {
+	test("loads, persists and reads a Float32 vector BLOB byte-identically (#198)", async () => {
+		const proc = Bun.spawn(["node", "--no-warnings", bundlePath], {
+			cwd: workDir,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env },
+		});
+		const [stdout, stderr] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		await proc.exited;
+
+		if (proc.exitCode !== 0) {
+			console.error("--- node store probe stdout ---\n" + stdout);
+			console.error("--- node store probe stderr ---\n" + stderr);
+		}
+
+		// Must not hit the #198 bun: scheme failure.
+		expect(stderr).not.toContain("protocol 'bun:'");
+		expect(proc.exitCode).toBe(0);
+
+		const line = stdout.trim().split("\n").pop() ?? "{}";
+		const result = JSON.parse(line) as {
+			driver: string; count: number; vectorIdentical: boolean;
+			topId: string | null; topDistance: number | null;
+		};
+
+		expect(result.driver).toBe("node:sqlite"); // confirms the Node path ran
+		expect(result.count).toBe(1);
+		expect(result.vectorIdentical).toBe(true); // byte-identical BLOB round-trip
+		expect(result.topId).toBe("m1");
+		expect(result.topDistance).toBe(0); // identical vector → zero cosine distance
+	}, 30_000);
+});

--- a/testing/src/integration/store-node-runtime.test.ts
+++ b/testing/src/integration/store-node-runtime.test.ts
@@ -25,6 +25,8 @@ import { tmpdir } from "node:os";
 
 const STORE_ENTRY = resolve(__dirname, "../../../plugin/src/store/index.ts");
 const DRIVER_ENTRY = resolve(__dirname, "../../../plugin/src/store/driver.ts");
+const NAMES_ENTRY = resolve(__dirname, "../../../plugin/src/names.ts");
+const TELEMETRY_ENTRY = resolve(__dirname, "../../../plugin/src/telemetry.ts");
 
 let workDir: string;
 let bundlePath: string;
@@ -44,11 +46,13 @@ beforeAll(async () => {
 	// Probe imports the REAL store + driver and performs a full round-trip.
 	const probeTs = join(workDir, "probe.ts");
 	writeFileSync(probeTs, `
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as store from ${JSON.stringify(STORE_ENTRY)};
 import { driverName } from ${JSON.stringify(DRIVER_ENTRY)};
+import { nameRegistry } from ${JSON.stringify(NAMES_ENTRY)};
+import { ledger, activityLog } from ${JSON.stringify(TELEMETRY_ENTRY)};
 
 const dir = mkdtempSync(join(tmpdir(), "codexfi-node-db-"));
 store._setStorePathForTests(dir);
@@ -75,13 +79,33 @@ for (let i = 0; i < vec.length && identical; i++) {
 const results = store.search(vec, { limit: 3 });
 const top = results[0];
 
-console.log(JSON.stringify({
-  driver: driverName(),
-  count: store.countRows(),
-  vectorIdentical: identical,
-  topId: top ? top.id : null,
-  topDistance: top ? Number(top._distance.toFixed(6)) : null,
-}));
+// Exercise the telemetry/names hot path — these use the cross-runtime fsx
+// helpers. Under Node, the previous Bun.file/Bun.write calls threw
+// "Bun is not defined", silently breaking name + cost persistence (#198).
+const main = async () => {
+  await nameRegistry.init(dir);
+  await nameRegistry.register("u", "Display Name");
+  await ledger.init(dir);
+  await ledger.recordVoyage(1234);
+  await activityLog.init(dir);
+  activityLog.recordVoyage(1234, 0.0001);
+  // Give the fire-and-forget activity save a tick to flush.
+  await new Promise((r) => setTimeout(r, 50));
+
+  const names = JSON.parse(readFileSync(join(dir, "names.json"), "utf8"));
+  const costs = JSON.parse(readFileSync(join(dir, "costs.json"), "utf8"));
+
+  console.log(JSON.stringify({
+    driver: driverName(),
+    count: store.countRows(),
+    vectorIdentical: identical,
+    topId: top ? top.id : null,
+    topDistance: top ? Number(top._distance.toFixed(6)) : null,
+    nameSaved: names.u === "Display Name",
+    costSaved: costs.voyage && costs.voyage.calls === 1,
+  }));
+};
+main().catch((e) => { console.error("FAIL:", e && e.message ? e.message : String(e)); process.exit(1); });
 `.trimStart());
 
 	// Bundle for the Node target — same as the shipped plugin build.
@@ -97,8 +121,8 @@ console.log(JSON.stringify({
 	}
 });
 
-describe("store round-trip under Node runtime (node:sqlite)", () => {
-	test("loads, persists and reads a Float32 vector BLOB byte-identically (#198)", async () => {
+describe("store + telemetry round-trip under Node runtime (node:sqlite + fsx)", () => {
+	test("loads, persists store/names/costs and reads a Float32 vector BLOB byte-identically (#198)", async () => {
 		const proc = Bun.spawn(["node", "--no-warnings", bundlePath], {
 			cwd: workDir,
 			stdout: "pipe",
@@ -124,6 +148,7 @@ describe("store round-trip under Node runtime (node:sqlite)", () => {
 		const result = JSON.parse(line) as {
 			driver: string; count: number; vectorIdentical: boolean;
 			topId: string | null; topDistance: number | null;
+			nameSaved: boolean; costSaved: boolean;
 		};
 
 		expect(result.driver).toBe("node:sqlite"); // confirms the Node path ran
@@ -131,5 +156,7 @@ describe("store round-trip under Node runtime (node:sqlite)", () => {
 		expect(result.vectorIdentical).toBe(true); // byte-identical BLOB round-trip
 		expect(result.topId).toBe("m1");
 		expect(result.topDistance).toBe(0); // identical vector → zero cosine distance
+		expect(result.nameSaved).toBe(true); // NameRegistry.save() works under Node (no Bun.write)
+		expect(result.costSaved).toBe(true); // CostLedger.save() works under Node (no Bun.write)
 	}, 30_000);
 });

--- a/website/content/docs/how-it-works/overview.mdx
+++ b/website/content/docs/how-it-works/overview.mdx
@@ -87,16 +87,18 @@ This means memory is never lost to compaction.
 
 | Component | Technology |
 |-----------|-----------|
-| Storage | SQLite with WAL mode (`bun:sqlite`) — zero npm dependencies, multi-agent safe, ACID transactions |
+| Storage | SQLite with WAL mode — built in to the runtime (`bun:sqlite` on Bun, `node:sqlite` on Node), zero npm dependencies, multi-agent safe, ACID transactions |
 | Search | Exact nearest neighbor cosine similarity over Float32Array BLOBs |
 | Embeddings | [Voyage AI](https://www.voyageai.com/) `voyage-code-3` — 1024 dimensions |
 | Extraction | Multi-provider LLM (Anthropic/xAI/Google) with automatic fallback |
-| Runtime | [Bun](https://bun.sh/) |
+| Runtime | [Bun](https://bun.sh/) (OpenCode CLI/TUI) · Node/Electron (OpenCode Desktop) — the plugin is runtime-adaptive |
 | Validation | [Zod](https://zod.dev/) schemas for memory records |
 
 ### Why SQLite?
 
-codexfi originally used LanceDB for vector storage. LanceDB is excellent software, but its native NAPI bindings broke on OpenCode Desktop auto-updates — users got cryptic module loading errors with no workaround. We replaced it with `bun:sqlite`, which is built into the Bun runtime (like `node:fs` is built into Node) — zero npm packages, zero native binaries, zero breakage on updates.
+codexfi originally used LanceDB for vector storage. LanceDB is excellent software, but its native NAPI bindings broke on OpenCode Desktop auto-updates — users got cryptic module loading errors with no workaround. We replaced it with SQLite, which ships **built in** to the JavaScript runtime (like `node:fs`) — zero npm packages, zero native binaries to rebuild per platform.
+
+OpenCode runs the plugin under two runtimes: **Bun** for the CLI/TUI, and **Node** (an Electron `utilityProcess`) for the Desktop app. The store is therefore **runtime-adaptive** — it loads `bun:sqlite` under Bun and `node:sqlite` under Node. Both are built-in drivers that share the identical on-disk file format, so the same `~/.codexfi` database is read and written by either runtime with no migration. This keeps the "zero native dependencies" guarantee on every OpenCode surface.
 
 SQLite with WAL (Write-Ahead Logging) also solves multi-agent concurrency. Many developers run multiple OpenCode agents simultaneously. WAL mode allows 100+ concurrent readers without blocking, with writers safely queued via `busy_timeout`. This was validated with stress tests spawning 20+ real OS processes hitting the same database file — zero data loss, zero corruption.
 
@@ -104,7 +106,7 @@ SQLite with WAL (Write-Ahead Logging) also solves multi-agent concurrency. Many 
 |---|---|---|---|
 | Concurrent reads | Yes | 100+ readers, zero blocking | Stale data |
 | Concurrent writes | Untested with multi-process | Single writer, others queue safely | Data loss |
-| Native dependencies | NAPI binary (broke on updates) | None (built into Bun) | None |
+| Native dependencies | NAPI binary (broke on updates) | None (built into Bun & Node) | None |
 | Storage size (3.5k records) | ~35MB | ~35MB | ~93MB |
 | Search at 50k records | ~2ms (indexed) | ~20ms (exact NN) | ~20ms (exact NN) |
 | Crash recovery | Lance format | Full ACID | Atomic rename only |


### PR DESCRIPTION
Fixes #198.

## Problem
The plugin assumed it always runs under **Bun**. The opencode **desktop app** hosts plugins under **Node** (Electron `utilityProcess` sidecar), which surfaced as **two** failures of the same root cause:

1. **Load-time:** a static `import { Database } from "bun:sqlite"` made Node's ESM loader throw `Only URLs with a scheme in: file, data, node ... Received protocol 'bun:'` — aborting plugin load entirely.
2. **Runtime hot-path:** even after the store loaded, `names.ts`/`telemetry.ts`/`retry.ts` used Bun-only globals (`Bun.file`, `Bun.write`, `Bun.sleep`) → `ReferenceError: Bun is not defined` on every `save()`, freezing `activity.json`/`costs.json`.

Net effect: **all memory silently disabled** on the desktop app (no extraction, embedding, or writes). The CLI/TUI (Bun) was unaffected.

## Fix
Make the plugin **runtime-agnostic** on every path that the host can execute under Node.

A runtime-adaptive SQLite driver selects the built-in by runtime via a **computed** `require` (so the wrong builtin is never statically resolved by either the bundler or the host loader):

- **Bun** (CLI/TUI) → `bun:sqlite`
- **Node** (desktop sidecar) → `node:sqlite`

Both are built-in → zero npm/native deps preserved, **same on-disk file format → no migration**.

### Changes
**Commit 1 — runtime-adaptive SQLite driver**
- `plugin/src/store/driver.ts` *(new)* — runtime detection + unified `DatabaseLike` adapter. Maps `run`→`exec` and wraps a manual `BEGIN/COMMIT/ROLLBACK` for `node:sqlite` (which has no `transaction()` helper).
- `plugin/src/store/sqlite.ts`, `crud.ts` — use the adapter; remove static `bun:sqlite` imports; `SQLQueryBindings`→local `Bindings`; BLOB type `Buffer`→`Uint8Array` (`node:sqlite` returns `Uint8Array`; existing `blobToVector` already normalises both).
- `testing/.../plugin-load.test.ts` — now spawns the bundle under **both** `bun` and `node`; fails on a `bun:` import regression (verified it reproduces the exact #198 error).
- `testing/.../store-node-runtime.test.ts` *(new)* — bundles the real store with `bun build --target node`, runs under `node`, asserts a **byte-identical Float32 vector BLOB round-trip** under `node:sqlite`.

**Commit 2 — cross-runtime file/sleep APIs** *(surfaced by a real desktop-app test)*
- `plugin/src/fsx.ts` *(new)* — `node:fs/promises`-based helpers that work on Bun **and** Node: `readJsonFile`, `writeTextFile`, `sleep`.
- Refactored `names.ts`, `telemetry.ts` (CostLedger + ActivityLog), `retry.ts` to drop `Bun.file`/`Bun.write`/`Bun.sleep`.
- CLI-only `Bun.serve`/`Bun.spawn` (dashboard) intentionally left — they only ever run under the Bun CLI and are not imported by the plugin entry.
- Extended the Node-spawned test to also assert `names.json`/`costs.json` are written under Node.

**Commit 3 — JSDoc + documentation correctness**
- `plugin/src/store/driver.ts` — full JSDoc (`@param`/`@returns`) on the exported `Bindings`, `Statement`, `isBun()`, `driverName()`, `openDatabase()` (clears the `opencode-review` warning).
- `website/content/docs/how-it-works/overview.mdx` — the docs claimed storage was `bun:sqlite` only and that SQLite gave "zero breakage on updates" — a claim #198 disproved. Updated the Storage/Runtime rows and the "Why SQLite?" section to document the runtime-adaptive driver (`bun:sqlite` on Bun, `node:sqlite` on Node) while keeping the truthful zero-native-deps promise across both runtimes.

## Verification (local)
- ✅ `bun build --target node` keeps both builtins external (only the computed string remains; no static `from "bun:sqlite"`).
- ✅ Installed bundle loads under Node (was throwing `protocol 'bun:'` before).
- ✅ **Real desktop-app e2e:** patched bundle installed into the Electron/Node sidecar — `chat.message` → search → embed runs, `0` `bun:`/`Bun is not defined` errors, `activity.json`/`costs.json` writing again, store memory count climbing.
- ✅ Real data: read + vector search over **4000+ memories** in the existing 44MB `store.db` (written by `bun:sqlite`) — identical results under Node and Bun, no migration.
- ✅ Cross-runtime durability: write under Node → read under Bun (and vice-versa) — vectors intact.
- ✅ `typecheck` clean; **212 tests pass / 0 fail** (209 unit/integration + 3 stress).
- ✅ Website builds clean (`pnpm build`) after the docs edit.
- ✅ Regression guard confirmed: reintroducing a used `bun:sqlite` import makes the Node test fail with the exact #198 error.

## Acceptance criteria
- [x] Plugin loads under desktop (Node) **and** CLI/TUI (Bun)
- [x] Extraction/embedding/store writes function under both (store round-trip + real desktop e2e)
- [x] Existing `~/.codexfi` data read correctly — **no migration**
- [x] Vector BLOB round-trip byte-identical under `node:sqlite`
- [x] `plugin-load` test covers a `node`-spawned bundle and fails on a `bun:` regression
- [x] No regression for Bun/CLI users
- [x] Docs reflect the runtime-adaptive storage layer
