### PR TITLE
docs(installation): correct false auto-update claim (#160)

### DIFF
--- a/website/content/docs/installation.mdx
+++ b/website/content/docs/installation.mdx
@@ -120,7 +120,7 @@ See the [OpenCode setup guide](/docs/guides/opencode-setup) for the recommended 
 
 ## Updating
 
-OpenCode installs plugins on first use and **pins the resolved version** in its cache (`~/.cache/opencode/packages/.../package.json` and `package-lock.json`). Once a version is cached, OpenCode keeps using it — **updates are not automatic**, even when the `plugin` array lists `codexfi` without a version. You stay on the pinned version until you explicitly update the cache.
+OpenCode installs plugins on first use and **pins the resolved version** in its cache (`~/.cache/opencode/packages/codexfi@latest/package.json` and `package-lock.json`). Once a version is cached, OpenCode keeps using it — **updates are not automatic**, even when the `plugin` array lists `codexfi` without a version. You stay on the pinned version until you explicitly update the cache.
 
 To update to the latest release, refresh the cached package and then restart OpenCode:
 

--- a/website/content/docs/installation.mdx
+++ b/website/content/docs/installation.mdx
@@ -120,13 +120,27 @@ See the [OpenCode setup guide](/docs/guides/opencode-setup) for the recommended 
 
 ## Updating
 
-OpenCode auto-installs npm plugins at startup and caches them in `~/.cache/opencode/node_modules/`. This means updates are automatic — you always get the latest version without manual action.
+OpenCode installs plugins on first use and **pins the resolved version** in its cache (`~/.cache/opencode/packages/.../package.json` and `package-lock.json`). Once a version is cached, OpenCode keeps using it — **updates are not automatic**, even when the `plugin` array lists `codexfi` without a version. You stay on the pinned version until you explicitly update the cache.
 
-To force a reinstall:
+To update to the latest release, refresh the cached package and then restart OpenCode:
 
 ```bash
-bunx codexfi install
+# Update the version OpenCode has cached
+npm install codexfi@latest --prefix ~/.cache/opencode/packages/codexfi@latest
+
+# Then fully restart OpenCode (quit and reopen the desktop app,
+# or restart the CLI) so the new version is loaded.
 ```
+
+> **Desktop app:** the cache is shared, but the app must be fully quit and reopened for the new version to take effect — reloading a session is not enough.
+
+You can confirm the active version at any time:
+
+```bash
+cat ~/.cache/opencode/packages/codexfi@latest/package.json | grep '"codexfi"'
+```
+
+To pin a specific release instead of the latest, replace `codexfi@latest` with `codexfi@<version>` (for example `codexfi@0.7.3`).
 
 ## Uninstalling
 


### PR DESCRIPTION
## Summary

Fixes #160 — the **Updating** section of `installation.mdx` falsely claimed plugin updates are automatic.

The old text said OpenCode auto-installs npm plugins at startup and "you always get the latest version without manual action." **This is false.** OpenCode resolves a plugin version once and pins it in its package cache (`package.json` + `package-lock.json`); it keeps using that pinned version even when the `plugin` array lists `codexfi` with no version. Confirmed live this session: after `codexfi@0.7.3` was published, the desktop app stayed on the previously cached version until the cache was manually refreshed and the app fully restarted.

## Changes

- Rewrote the **Updating** section to describe the real (pinned-cache) behavior.
- Documented the verified update procedure: `npm install codexfi@latest --prefix ~/.cache/opencode/packages/codexfi@latest`, then **fully restart** OpenCode.
- Added a desktop-app note (reloading a session is not enough — must quit and reopen).
- Added a version-check command and a note on pinning a specific release.

## Verification

| Check | Result |
|---|---|
| False claim reproduced live | ✅ desktop stayed on old version post-0.7.3 release |
| New update procedure | ✅ used this session to move all installs to 0.7.3 |
| Other docs scanned for same claim | ✅ no other "auto-update" claims (remaining "automatic" mentions refer to memory extraction / provider fallback, all correct) |
| Scope | Docs only — single file, no code/runtime changes |
| CI / Test / Build / CodeQL / review bot | ✅ all green |

## Notes

@clarkbalan — merging this one yourself as requested.

---

### Update log
- `45fcf21` — addressed opencode-review suggestion: use the concrete cache path (`~/.cache/opencode/packages/codexfi@latest/package.json`) in the explanatory sentence for consistency with the command examples. Review passed with 0 Critical / 0 Warning.
