### PR TITLE
chore(deps): batch bump @opencode-ai/{plugin,sdk} 1.17.11 + actions/checkout v7 (#211, #214, #215)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dorny/paths-filter@v4
         id: changes
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dorny/paths-filter@v4
         id: changes

--- a/.github/workflows/opencode-comment.yml
+++ b/.github/workflows/opencode-comment.yml
@@ -29,7 +29,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -31,7 +31,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/opencode-scheduled.yml
+++ b/.github/workflows/opencode-scheduled.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write         # Open issues for anything worth tracking
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/opencode-triage.yml
+++ b/.github/workflows/opencode-triage.yml
@@ -39,7 +39,7 @@ jobs:
       issues: write      # Post triage comment
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         working-directory: plugin
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,7 @@ jobs:
       run:
         working-directory: plugin
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/plugin/bun.lock
+++ b/plugin/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "codexfi",
       "dependencies": {
-        "@opencode-ai/plugin": "^1.16.2",
-        "@opencode-ai/sdk": "^1.16.2",
+        "@opencode-ai/plugin": "^1.17.11",
+        "@opencode-ai/sdk": "^1.17.11",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -16,6 +16,8 @@
     },
   },
   "packages": {
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
@@ -28,9 +30,9 @@
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.17.7", "", { "dependencies": { "@opencode-ai/sdk": "1.17.7", "effect": "4.0.0-beta.74", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.3.4", "@opentui/keymap": ">=0.3.4", "@opentui/solid": ">=0.3.4" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-/MXRdz5z5tDySwMM4v02cN0om1QgALyE8FTXFU93zKV4I/oW5a0IjQ7dK8Iue3NpRc9e5UHhgO5ELeNLqnpWPA=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.17.12", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/sdk": "1.17.12", "effect": "4.0.0-beta.83", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.3.4", "@opentui/keymap": ">=0.3.4", "@opentui/solid": ">=0.3.4" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-hTfR1sj+EqoYY/lAphxSyt63xs/ZpHFyvP1ekf1UEysdnOEa5mTLTevDu1cq1aHLqcECRGBIjf7iBlNGLCguAg=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.7", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-7q7StGM+N0OwUgRsmDc8Gyz3hMIH1XGig+qZ4lzWUpmSgFEjLx8U7R14GXY7KiMJVdbVf6FeaYloRz2Rcsma4A=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.12", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-N8kazWO0ZLCHWYFuZQt1UJM+bWxY6g1auSG6SvD1+K3+W+nw2qIhDAUGNCD0KVW3bY2LCwvfWvpG2ZbVGCHC0Q=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -44,7 +46,7 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "effect": ["effect@4.0.0-beta.74", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA=="],
+    "effect": ["effect@4.0.0-beta.83", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w=="],
 
     "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
 
@@ -53,6 +55,8 @@
     "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.7.4",
 			"license": "MIT",
 			"dependencies": {
-				"@opencode-ai/plugin": "^1.15.12",
-				"@opencode-ai/sdk": "^1.15.12",
+				"@opencode-ai/plugin": "^1.17.11",
+				"@opencode-ai/sdk": "^1.17.11",
 				"zod": "^4.4.3"
 			},
 			"bin": {
@@ -19,6 +19,18 @@
 			"devDependencies": {
 				"@types/bun": "1.3.14",
 				"typescript": "6.0.3"
+			}
+		},
+		"node_modules/@ai-sdk/provider": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+			"integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"json-schema": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -100,19 +112,20 @@
 			]
 		},
 		"node_modules/@opencode-ai/plugin": {
-			"version": "1.15.12",
-			"resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.12.tgz",
-			"integrity": "sha512-BBteGXEwJt+1ehHqQ+yKXmoWltrW+2xO++B1Fm/dnMGYWT9luEKA5RlUuVYA2qDF6uwlE7kmHZvQZAM79zWHEA==",
+			"version": "1.17.12",
+			"resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.12.tgz",
+			"integrity": "sha512-hTfR1sj+EqoYY/lAphxSyt63xs/ZpHFyvP1ekf1UEysdnOEa5mTLTevDu1cq1aHLqcECRGBIjf7iBlNGLCguAg==",
 			"license": "MIT",
 			"dependencies": {
-				"@opencode-ai/sdk": "1.15.12",
-				"effect": "4.0.0-beta.66",
+				"@ai-sdk/provider": "3.0.8",
+				"@opencode-ai/sdk": "1.17.12",
+				"effect": "4.0.0-beta.83",
 				"zod": "4.1.8"
 			},
 			"peerDependencies": {
-				"@opentui/core": ">=0.2.16",
-				"@opentui/keymap": ">=0.2.16",
-				"@opentui/solid": ">=0.2.16"
+				"@opentui/core": ">=0.3.4",
+				"@opentui/keymap": ">=0.3.4",
+				"@opentui/solid": ">=0.3.4"
 			},
 			"peerDependenciesMeta": {
 				"@opentui/core": {
@@ -136,9 +149,9 @@
 			}
 		},
 		"node_modules/@opencode-ai/sdk": {
-			"version": "1.15.12",
-			"resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.12.tgz",
-			"integrity": "sha512-lOaBNX93dkakZe6C42ttX1bkSx3K2c6+Yv+w8Qv02v5rPlu1vCXbmdfYDh9/bw+oq+NKPSaBm9d6kPA19hA5Lg==",
+			"version": "1.17.12",
+			"resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.12.tgz",
+			"integrity": "sha512-N8kazWO0ZLCHWYFuZQt1UJM+bWxY6g1auSG6SvD1+K3+W+nw2qIhDAUGNCD0KVW3bY2LCwvfWvpG2ZbVGCHC0Q==",
 			"license": "MIT",
 			"dependencies": {
 				"cross-spawn": "7.0.6"
@@ -205,21 +218,21 @@
 			}
 		},
 		"node_modules/effect": {
-			"version": "4.0.0-beta.66",
-			"resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.66.tgz",
-			"integrity": "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==",
+			"version": "4.0.0-beta.83",
+			"resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
+			"integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
-				"fast-check": "^4.6.0",
+				"fast-check": "^4.8.0",
 				"find-my-way-ts": "^0.1.6",
-				"ini": "^6.0.0",
+				"ini": "^7.0.0",
 				"kubernetes-types": "^1.30.0",
-				"msgpackr": "^1.11.9",
+				"msgpackr": "^2.0.1",
 				"multipasta": "^0.2.7",
 				"toml": "^4.1.1",
-				"uuid": "^13.0.0",
-				"yaml": "^2.8.3"
+				"uuid": "^14.0.0",
+				"yaml": "^2.9.0"
 			}
 		},
 		"node_modules/fast-check": {
@@ -251,12 +264,12 @@
 			"license": "MIT"
 		},
 		"node_modules/ini": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-			"integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+			"integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
 			"license": "ISC",
 			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
 			}
 		},
 		"node_modules/isexe": {
@@ -265,6 +278,12 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
 		},
+		"node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+			"license": "(AFL-2.1 OR BSD-3-Clause)"
+		},
 		"node_modules/kubernetes-types": {
 			"version": "1.30.0",
 			"resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
@@ -272,12 +291,12 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/msgpackr": {
-			"version": "1.11.12",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
-			"integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+			"integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
 			"license": "MIT",
 			"optionalDependencies": {
-				"msgpackr-extract": "^3.0.2"
+				"msgpackr-extract": "^3.0.4"
 			}
 		},
 		"node_modules/msgpackr-extract": {
@@ -333,9 +352,9 @@
 			}
 		},
 		"node_modules/pure-rand": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-			"integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.1.tgz",
+			"integrity": "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==",
 			"funding": [
 				{
 					"type": "individual",
@@ -370,9 +389,9 @@
 			}
 		},
 		"node_modules/toml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
-			"integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/toml/-/toml-4.1.2.tgz",
+			"integrity": "sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
@@ -400,9 +419,9 @@
 			"license": "MIT"
 		},
 		"node_modules/uuid": {
-			"version": "13.0.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-			"integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -17,8 +17,8 @@
 		"smoke:e2e": "bun run src/smoke-e2e.ts"
 	},
 	"dependencies": {
-		"@opencode-ai/plugin": "^1.16.2",
-		"@opencode-ai/sdk": "^1.16.2",
+		"@opencode-ai/plugin": "^1.17.11",
+		"@opencode-ai/sdk": "^1.17.11",
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

Batches **three Dependabot PRs** into a single change to reduce CI churn and keep all lockfiles consistent. Supersedes #211, #214, and #215.

| # | Dependency | From | To | Scope |
|---|------------|------|----|-------|
| #215 | `@opencode-ai/plugin` | `^1.16.2` | `^1.17.11` (resolves **1.17.12**) | `plugin/` |
| #214 | `@opencode-ai/sdk` | `^1.16.2` | `^1.17.11` (resolves **1.17.12**) | `plugin/` |
| #211 | `actions/checkout` | `v6` | `v7` | 7 workflow files |

> Note: the npm `package-lock.json` had drifted to `^1.15.12` while `package.json` and `bun.lock` were already on `^1.16.2`. This PR realigns **all three** lockfiles to `^1.17.11` so they no longer disagree. `^1.17.11` legitimately resolves to the latest patch `1.17.12` (published after Dependabot opened the PRs).

## Changes

**Dependency bump (`plugin/`)**
- `package.json` — `@opencode-ai/plugin` & `@opencode-ai/sdk` → `^1.17.11`
- `bun.lock` — regenerated (the lockfile CI actually uses via `bun install --frozen-lockfile`), resolves `1.17.12`
- `package-lock.json` — regenerated to match (npm lockfile kept in sync)
- Transitive: pulls in `@ai-sdk/provider@3.0.8` + `json-schema@0.4.0`; bumps `effect` `4.0.0-beta.74 → 4.0.0-beta.83`

**CI action bump (`.github/workflows/`)**
- `actions/checkout@v6 → v7` in: `ci.yml` (×2), `opencode-comment.yml`, `opencode-review.yml`, `opencode-scheduled.yml`, `opencode-triage.yml`, `publish.yml`, `release-please.yml` (8 occurrences, 7 files)

## Verification

All run locally against the upgraded versions:

| Check | Command | Result |
|-------|---------|--------|
| Lockfile integrity | `bun install --frozen-lockfile` | ✅ clean (no changes) |
| Type check | `bunx tsc --noEmit` | ✅ 0 errors |
| Build plugin | `bun run build:plugin` | ✅ 101 modules |
| Build CLI | `bun run build:cli` | ✅ 36 modules |
| Unit tests | `bun test src/unit/` | ✅ 173 pass |
| Integration tests | `bun test src/integration/` | ✅ 36 pass |

**Total: 209/209 tests pass.**

## Risk & Mitigation

- **Risk:** `@opencode-ai/plugin`/`sdk` is the core host SDK — a breaking change could affect plugin hooks (`chat.message`, `event`).
  - **Mitigation:** Full build + 209-test suite pass; minor/patch semver within the same major (`1.x`); peer-dep range already satisfied (`@opentui/* >=0.3.4`). No source changes required.
- **Risk:** `actions/checkout v7` is a major bump.
  - **Mitigation:** v7's main change is the runtime/Node bump; no usage in our workflows relies on removed behavior. `persist-credentials: false` usages preserved. CI runs on this PR (touches `ci.yml`) so the new action is exercised end-to-end before merge.
- **Risk:** lockfile resolved `1.17.12` rather than the `1.17.11` Dependabot named.
  - **Mitigation:** `^1.17.11` permits `1.17.12`; verified consistent across `bun.lock` + `package-lock.json`.

## Closes

Closes #211
Closes #214
Closes #215

---
<sub>Awaiting `opencode-review` 🤖</sub>
